### PR TITLE
Conjunct improvements

### DIFF
--- a/src/Database/Design/Ampersand/Prototype/Generate.hs
+++ b/src/Database/Design/Ampersand/Prototype/Generate.hs
@@ -247,13 +247,21 @@ generateConjuncts fSpec =
            ]
          | conj<-vconjs fSpec
          , let rExpr=rc_conjunct conj
-         , let signalRuleNames = [ showPhpStr $ name r | r <- rc_orgRules conj, isSignal r ] 
-         , let invRuleNames    = [ showPhpStr $ name r | r <- rc_orgRules conj, not $ isSignal r, not $ ruleIsInvariantUniOrInj r ]
+         , let signalRuleNames = [ showPhpStr $ name r | r <- rc_orgRules conj, isFrontEndSignal r ] 
+         , let invRuleNames    = [ showPhpStr $ name r | r <- rc_orgRules conj, isFrontEndInvariant  r ]
          , let violExpr = notCpl rExpr
          , let violationsExpr = conjNF (getOpts fSpec) violExpr
          ]
      ) )
-    
+
+-- Because the signal/invariant condition appears both in generateConjuncts and generateInterface, we use
+-- two abstractions to guarantee the same implementation.
+isFrontEndInvariant :: Rule -> Bool
+isFrontEndInvariant r = not (isSignal r) && not (ruleIsInvariantUniOrInj r)
+
+isFrontEndSignal :: Rule -> Bool
+isFrontEndSignal r = isSignal r
+
 generateRoles :: FSpec -> [String]
 generateRoles fSpec =
   [ "$allRoles ="
@@ -318,8 +326,11 @@ generateInterface fSpec interface =
   indent 2 (genInterfaceObjects fSpec (ifcParams interface) (Just $ topLevelFields) 1 (ifcObj interface))
   where topLevelFields = -- for the top-level interface object we add the following fields (saves us from adding an extra interface node to the php data structure)
           [ "      , 'interfaceRoles' => array (" ++ intercalate ", " (map showPhpStr $ ifcRoles interface) ++")" 
-          , "      , 'conjunctIds' => array ("++intercalate ", " (map (showPhpStr . rc_id) $ ifcControls interface) ++")"
+          , "      , 'invConjunctIds' => array ("++intercalate ", " (map (showPhpStr . rc_id) $ invConjuncts) ++")"
+          , "      , 'sigConjunctIds' => array ("++intercalate ", " (map (showPhpStr . rc_id) $ sigConjuncts) ++")"
           ]
+        invConjuncts = [ c | c <- ifcControls interface, any isFrontEndInvariant $ rc_orgRules c ] -- NOTE: these two
+        sigConjuncts = [ c | c <- ifcControls interface, any isFrontEndSignal    $ rc_orgRules c ] --       may overlap
 
 genInterfaceObjects :: FSpec -> [Expression] -> Maybe [String] -> Int -> ObjectDef -> [String]
 genInterfaceObjects fSpec editableRels mTopLevelFields depth object =

--- a/src/Database/Design/Ampersand/Prototype/Generate.hs
+++ b/src/Database/Design/Ampersand/Prototype/Generate.hs
@@ -13,6 +13,7 @@ import Database.Design.Ampersand.FSpec.FSpec
 import Database.Design.Ampersand.Prototype.ProtoUtil
 import Database.Design.Ampersand.Prototype.RelBinGenSQL
 import qualified Database.Design.Ampersand.Prototype.ValidateEdit as ValidateEdit 
+import Database.Design.Ampersand.Prototype.PHP (getTableName, signalTableSpec)
 import Control.Exception
 
 fatal :: Int -> String -> a
@@ -80,6 +81,8 @@ generateConstants fSpec =
   , ""
   , "$dbName =  isset($isValidationSession) && $isValidationSession ? "++showPhpStr ValidateEdit.tempDbName++" : "++showPhpStr (dbName opts)++";"
   , "// If this script is called with $isValidationSession == true, use the temporary db name instead of the normal one." 
+  , ""
+  , "$signalTableName = "++showPhpStr (getTableName signalTableSpec)++";"
   , ""
   , "$isDev = "++showPhpBool (development opts)++";"
   , ""


### PR DESCRIPTION
More consistent and efficient way to handle conjuncts. Some small changes may follow, but the representation of conjuncts in Generics.php will most likely remain stable from here on. Also, signal conjuncts are now cached in a single sql table (ticket 449).

Note that there might be some breakage due to changes in Generics.php (in $allInterfaces, conjunctIds is replaced by invConjunctIds and sigConjunctIds).