### PR TITLE
Experimental interface ref check

### DIFF
--- a/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
+++ b/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
@@ -180,14 +180,14 @@ pCtx2aCtx' _
       <*> traverse (pRul2aRul [] n1) p_rules       --  All user defined rules in this context, but outside patterns and outside processes
       <*> traverse pIdentity2aIdentity p_identdefs --  The identity definitions defined in this context, outside the scope of patterns
       <*> traverse pViewDef2aViewDef p_viewdefs    --  The view definitions defined in this context, outside the scope of patterns
-      <*> traverse pIfc2aIfc p_interfaceAndDisambObs   --  TODO: explain   ... The interfaces defined in this context, outside the scope of patterns
+      <*> traverse pIfc2aIfc p_interfaceAndDisambObjs   --  TODO: explain   ... The interfaces defined in this context, outside the scope of patterns
       <*> traverse pPurp2aPurp p_purposes          --  The purposes of objects defined in this context, outside the scope of patterns
       <*> traverse pPop2aPop p_pops                --  [Population]
       <*> traverse pObjDef2aObjDef p_sqldefs       --  user defined sqlplugs, taken from the Ampersand script
       <*> traverse pObjDef2aObjDef p_phpdefs       --  user defined phpplugs, taken from the Ampersand script
   where
-    p_interfaceAndDisambObs :: [(P_Interface, P_ObjDef (TermPrim, DisambPrim))]
-    p_interfaceAndDisambObs = [ (ifc, disambiguate termPrimDisAmb $ ifc_Obj ifc) | ifc <- p_interfaces ]
+    p_interfaceAndDisambObjs :: [(P_Interface, P_ObjDef (TermPrim, DisambPrim))]
+    p_interfaceAndDisambObjs = [ (ifc, disambiguate termPrimDisAmb $ ifc_Obj ifc) | ifc <- p_interfaces ]
     -- story about genRules and genLattice
     -- the genRules is a list of equalities between concept sets, in which every set is interpreted as a conjunction of concepts
     -- the genLattice is the resulting optimized structure
@@ -395,7 +395,7 @@ pCtx2aCtx' _
      
       lookupDisambIfcObj :: String -> Maybe (P_ObjDef (TermPrim, DisambPrim))
       lookupDisambIfcObj ifcId =
-        case [ disambObj | (vd,disambObj) <- p_interfaceAndDisambObs, ifc_Name vd == ifcId ] of
+        case [ disambObj | (vd,disambObj) <- p_interfaceAndDisambObjs, ifc_Name vd == ifcId ] of
           []          -> Nothing
           disambObj:_ -> Just disambObj -- return the first one, if there are more, this is caught later on by uniqueness static check
       

--- a/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
+++ b/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
@@ -374,7 +374,7 @@ pCtx2aCtx' _
        ) <$> typecheckTerm ctx <*> maybeOverGuarded pSubi2aSubi subs
      where
       unguard :: Guarded (Guarded a) -> Guarded a -- This function is a bit more compositional than <?> as you don't have to tuple all the arguments
-      unguard (Errors errs) = Errors errs
+      unguard (Errors errs) = Errors errs         -- (it will move to CtxError if we will actually use it)
       unguard (Checked g)   = g  
       
       isa :: String -> String -> Bool

--- a/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
+++ b/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
@@ -362,12 +362,12 @@ pCtx2aCtx' _
          (\(objExpr,bb) subi -> -- TODO: where is the tuple of  booleans (bb) documented? (so we can use a more appropriate name)
            case subi of
              Nothing -> obj (objExpr,bb) Nothing <$ typeCheckViewAnnotation objExpr mView -- TODO: move upward when we allow view annotations for boxes (and refs) as well
-             Just (InterfaceRef s) ->
+             Just (InterfaceRef ifcId) ->
                unguard $
-                 (\(refIfcExpr,_) -> (\objExprEps -> obj (objExprEps,bb) (Just $ InterfaceRef s)) <$> typeCheckInterfaceRef objExpr refIfcExpr)
-                 <$> case lookupDisambIfcObj s of
+                 (\(refIfcExpr,_) -> (\objExprEps -> obj (objExprEps,bb) (Just $ InterfaceRef ifcId)) <$> typeCheckInterfaceRef objExpr refIfcExpr)
+                 <$> case lookupDisambIfcObj ifcId of
                        Just disambObj -> typecheckTerm $ obj_ctx disambObj -- term is type checked twice, but otherwise we need a more complicated type check method to access already-checked interfaces
-                       Nothing     -> error "interface ref not found"
+                       Nothing     -> Errors [mkUndeclaredError "interface" Nothing o ifcId]
              Just bx@(Box c _ _) ->
                case findExact genLattice $ name c `mIsc` gc Tgt objExpr of -- TODO: does this always return a singleton? (and if so why not a maybe?)
                  []          -> mustBeOrdered o (Src, c, fromJust subs) (Tgt, target objExpr, objExpr)

--- a/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
+++ b/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
@@ -186,6 +186,7 @@ pCtx2aCtx' _
       <*> traverse pObjDef2aObjDef p_sqldefs       --  user defined sqlplugs, taken from the Ampersand script
       <*> traverse pObjDef2aObjDef p_phpdefs       --  user defined phpplugs, taken from the Ampersand script
   where
+    p_interfaceAndDisambObs :: [(P_Interface, P_ObjDef (TermPrim, DisambPrim))]
     p_interfaceAndDisambObs = [ (ifc, disambiguate termPrimDisAmb $ ifc_Obj ifc) | ifc <- p_interfaces ]
     -- story about genRules and genLattice
     -- the genRules is a list of equalities between concept sets, in which every set is interpreted as a conjunction of concepts
@@ -391,7 +392,7 @@ pCtx2aCtx' _
      
       lookupDisambIfcObj :: String -> Maybe (P_ObjDef (TermPrim, DisambPrim))
       lookupDisambIfcObj ifcId =
-        case [ disambObj | (vd,disambObj) <- p_interfaceAndObjDisambs, ifc_Name vd == ifcId ] of
+        case [ disambObj | (vd,disambObj) <- p_interfaceAndDisambObs, ifc_Name vd == ifcId ] of
           []    -> Nothing
           disambObj:_ -> Just disambObj -- return the first one, if there are more, this is caught later on by uniqueness static check
       

--- a/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
+++ b/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
@@ -776,6 +776,7 @@ pMarkup2aMarkup defLanguage defFormat
        fmt = fromMaybe defFormat mpdf           -- The pandoc format is always defined; if not by the user, then by default.
 
 -- helpers for generating a lattice, not having to write `Atom' all the time
+-- TODO: Names are inconsistent: maybe call these either mUnion & mIsc or mJoin & mMeet? Or even lJoin and lMeet to denote the lattice.
 mjoin,mIsc :: a -> a -> FreeLattice a
 mjoin a b = Join (Atom a) (Atom b)
 mIsc  a b = Meet (Atom a) (Atom b)

--- a/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
+++ b/src/Database/Design/Ampersand/ADL1/P2A_Converters.hs
@@ -460,7 +460,7 @@ pCtx2aCtx' _
          PDia _ a b -> binary' (.<>.) (ISC (Tgt,fst) (Src,snd)) ((Src,fst),(Tgt,snd)) Tgt Src <?> ((,)<$>tt a<*>tt b) -- MBE would have been correct, but too restrictive
          PCps _ a b -> binary' (.:.)  (ISC (Tgt,fst) (Src,snd)) ((Src,fst),(Tgt,snd)) Tgt Src <?> ((,)<$>tt a<*>tt b)
          PRad _ a b -> binary' (.!.)  (MBE (Tgt,fst) (Src,snd)) ((Src,fst),(Tgt,snd)) Tgt Src <?> ((,)<$>tt a<*>tt b) -- Using MBE instead of ISC allows the programmer to use De Morgan
-         PPrd _ a b -> (\((x,(s,_)),(y,(_,t))) -> (x .*. y, (s,t))) <$> ((,)<$>tt a<*>tt b)
+         PPrd _ a b -> (\(x,(s,_)) (y,(_,t)) -> (x .*. y, (s,t))) <$> tt a <*> tt b
          PKl0 _ a   -> unary   EKl0   (UNI (Src, id) (Tgt, id), UNI (Src, id) (Tgt, id)) <?> tt a
          PKl1 _ a   -> unary   EKl1   (UNI (Src, id) (Tgt, id), UNI (Src, id) (Tgt, id)) <?> tt a
          PFlp _ a   -> (\(x,(s,t)) -> ((EFlp x), (t,s))) <$> tt a

--- a/src/Database/Design/Ampersand/Input/ADL1/CtxError.hs
+++ b/src/Database/Design/Ampersand/Input/ADL1/CtxError.hs
@@ -11,7 +11,7 @@ module Database.Design.Ampersand.Input.ADL1.CtxError
   , mkIncompatibleViewError
   , Guarded(..)
   , whenCheckedIO
-  , (<?>)
+  , unguard, (<?>)
   )
 -- SJC: I consider it ill practice to export CTXE
 -- Reason: CtxError should obtain all error messages
@@ -35,7 +35,15 @@ fatal,_notUsed :: Int -> String -> a
 fatal = fatalMsg "Input.ADL1.CtxError"
 _notUsed = fatal
 
-infixl 4 <?>
+-- unguard is like an applicative join, which can be used to elegantly express monadic effects for Guarded.
+-- The function is a bit more compositional than <?> as you don't have to tuple all the arguments.
+-- Similar to join and bind we have: unguard g = id <?> g, and f <?> g = unguard $ f <$> g
+unguard :: Guarded (Guarded a) -> Guarded a
+unguard (Errors errs) = Errors errs
+unguard (Checked g)   = g  
+
+infixl 4 <?> -- TODO: in case we keep this one, why not lower the precedence? 
+             --       (3 to allow elegant combination with <*> and <$>, or 2 if we also take into account <|>, which may be unnecessary as Guarded is not an Alternative)
 (<?>) :: (t -> Guarded a) -> Guarded t -> Guarded a  -- This is roughly the monadic definition for >>=, but it does not satisfy the corresponding rules so it cannot be a monad
 (<?>) _ (Errors  a) = Errors a -- note the type change
 (<?>) f (Checked a) = f a

--- a/src/Database/Design/Ampersand/Input/ADL1/CtxError.hs
+++ b/src/Database/Design/Ampersand/Input/ADL1/CtxError.hs
@@ -104,10 +104,9 @@ mkDanglingPurposeError :: Purpose -> CtxError
 mkDanglingPurposeError p = CTXE (origin p) $ "Purpose refers to non-existent " ++ showADL (explObj p) 
 -- Unfortunately, we cannot use position of the explanation object itself because it is not an instance of Trace.
 
-mkUndeclaredError :: (Traced e, Named e) => String -> Maybe String -> e -> String -> CtxError
-mkUndeclaredError entity mIfcName objDef ref = 
-  CTXE (origin objDef) $ "Undeclared " ++ entity ++ " " ++ show ref ++ " referenced at field " ++ 
-                         show (name objDef) ++ maybe "" (\nm -> " of interface " ++ show nm) mIfcName ++ "."
+mkUndeclaredError :: (Traced e, Named e) => String -> e -> String -> CtxError
+mkUndeclaredError entity objDef ref = 
+  CTXE (origin objDef) $ "Undeclared " ++ entity ++ " " ++ show ref ++ " referenced at field " ++ show (name objDef)
 
 mkMultipleInterfaceError :: String -> Interface -> [Interface] -> CtxError
 mkMultipleInterfaceError role ifc duplicateIfcs = 

--- a/src/Database/Design/Ampersand/Input/ADL1/CtxError.hs
+++ b/src/Database/Design/Ampersand/Input/ADL1/CtxError.hs
@@ -6,7 +6,7 @@ module Database.Design.Ampersand.Input.ADL1.CtxError
   , mustBeOrdered, mustBeOrderedLst, mustBeOrderedConcLst
   , mustBeBound
   , GetOneGuarded(..), uniqueNames, mkDanglingPurposeError
-  , mkUndeclaredError, mkMultipleInterfaceError, mkInterfaceRefCycleError, mkNonMatchingError
+  , mkUndeclaredError, mkMultipleInterfaceError, mkInterfaceRefCycleError, mkIncompatibleInterfaceError
   , mkMultipleDefaultError
   , mkIncompatibleViewError
   , Guarded(..)
@@ -119,9 +119,11 @@ mkInterfaceRefCycleError cyclicIfcs@(ifc:_) = -- take the first one (there will 
   CTXE (origin ifc) $ "Interfaces form a reference cycle:\n" ++
                       unlines [ "- " ++ show (name i) ++ " at position " ++ show (origin i) | i <- cyclicIfcs ] 
                               
-mkNonMatchingError ::  String -> ObjectDef -> A_Concept -> A_Concept -> String -> CtxError 
-mkNonMatchingError entity objDef t s ref
- = CTXE (origin objDef) $ "The referenced "++entity++" "++show ref++" is of type "++show (name s)++", which does not match the required type "++show (name t)++"."
+mkIncompatibleInterfaceError ::  P_ObjDef a -> A_Concept -> A_Concept -> String -> CtxError 
+mkIncompatibleInterfaceError objDef expTgt refSrc ref = 
+  CTXE (origin objDef) $ "Incompatible interface reference "++ show ref ++" at field " ++ show (name objDef) ++ 
+                         ":\nReferenced interface "++show ref++" has type " ++ show (name refSrc) ++ 
+                         ", which is not comparable to the target " ++ show (name expTgt) ++ " of the expression at this field."
 
 mkMultipleDefaultError :: (A_Concept, [ViewDef]) -> CtxError
 mkMultipleDefaultError (_, [])              = fatal 118 "mkMultipleDefaultError called on []"


### PR DESCRIPTION
A less strict interface ref type check (comparable instead of equal). Also adds epsilon.