### PR TITLE
Fix for meta tables have underscore

### DIFF
--- a/src/Database/Design/Ampersand/Components.hs
+++ b/src/Database/Design/Ampersand/Components.hs
@@ -34,16 +34,13 @@ fatal = fatalMsg "Components"
 --    takes the FSpec as its input, and spits out everything the user requested.
 generateAmpersandOutput :: FSpec -> IO ()
 generateAmpersandOutput fSpec =
- do { verboseLn (getOpts fSpec) "Generating common Ampersand artifacts..."
-    ; when (genXML (getOpts fSpec))      $ doGenXML      fSpec
+ do { when (genXML (getOpts fSpec))      $ doGenXML      fSpec
     ; when (genUML (getOpts fSpec))      $ doGenUML      fSpec
     ; when (haskell (getOpts fSpec))     $ doGenHaskell  fSpec
     ; when (export2adl (getOpts fSpec))  $ doGenADL      fSpec
     ; when (genFSpec (getOpts fSpec))    $ doGenDocument fSpec
     ; when (genFPAExcel (getOpts fSpec)) $ doGenFPAExcel fSpec
     ; when (proofs (getOpts fSpec))      $ doGenProofs   fSpec
-    ; when (genGenericsFile (getOpts fSpec)) $ doGenGenericsPopulation Generics fSpec
-    ; when (genASTFile (getOpts fSpec))  $ doGenGenericsPopulation AST fSpec
     --; Prelude.putStrLn $ "Declared rules:\n" ++ show (map showADL $ vrules fSpec)
     --; Prelude.putStrLn $ "Generated rules:\n" ++ show (map showADL $ grules fSpec)
     --; Prelude.putStrLn $ "Violations:\n" ++ show (violations fSpec)
@@ -83,14 +80,6 @@ doGenHaskell fSpec =
     ; verboseLn (getOpts fSpec) $ "Haskell written into " ++ outputFile ++ "."
     }
  where outputFile = combine (dirOutput (getOpts fSpec)) $ replaceExtension (baseName (getOpts fSpec)) ".hs"
-
-doGenGenericsPopulation :: MetaType -> FSpec -> IO()
-doGenGenericsPopulation mType fSpec =
- do verboseLn (getOpts fSpec) $ "Generating meta-population for "++name fSpec
-    let (nm,content) = makeMetaPopulationFile mType fSpec
-        outputFile = combine (dirOutput (getOpts fSpec)) $ replaceExtension nm ".adl"
-    writeFile outputFile content
-    verboseLn (getOpts fSpec) $ "Meta population written into " ++ outputFile ++ "."
 
 doGenXML :: FSpec -> IO()
 doGenXML fSpec =

--- a/src/Database/Design/Ampersand/Core/AbstractSyntaxTree.hs
+++ b/src/Database/Design/Ampersand/Core/AbstractSyntaxTree.hs
@@ -262,10 +262,7 @@ aMarkup2String a = blocks2String (amFormat a) False (amPandoc a)
 data AMeaning = AMeaning { ameaMrk ::[A_Markup]} deriving (Show, Eq, Prelude.Ord)
 
 instance Named Declaration where
-  name d@Sgn{}   = case decnm d of
-                     []  -> fatal 266 "Declaration with an empty name!"
-                     c:cs -> if and [isAlpha c, isLower c]
-                            then c:cs
+  name d@Sgn{}   = decnm d
   name Isn{}     = "I"
   name Vs{}      = "V"
 instance Association Declaration where

--- a/src/Database/Design/Ampersand/Core/AbstractSyntaxTree.hs
+++ b/src/Database/Design/Ampersand/Core/AbstractSyntaxTree.hs
@@ -59,7 +59,6 @@ import Data.List (intercalate,nub,delete)
 import Data.Typeable
 import GHC.Generics (Generic)
 import Data.Hashable
-import Data.Char
 
 fatal :: Int -> String -> a
 fatal = fatalMsg "Core.AbstractSyntaxTree"
@@ -267,7 +266,6 @@ instance Named Declaration where
                      []  -> fatal 266 "Declaration with an empty name!"
                      c:cs -> if and [isAlpha c, isLower c]
                             then c:cs
-                            else show (c:cs)
   name Isn{}     = "I"
   name Vs{}      = "V"
 instance Association Declaration where
@@ -699,11 +697,7 @@ instance Hashable A_Concept where
                         ONE            -> (1::Int)
                       ) 
 instance Named A_Concept where
-  name PlainConcept{cptnm = nm} = case nm of
-                                   []    -> fatal 703 "Concept with an empty name!"
-                                   (c:_) -> if and [isAlpha c, isUpper c]
-                                            then nm
-                                            else show nm
+  name PlainConcept{cptnm = nm} = nm
   name ONE = "ONE"
 
 instance Show A_Concept where

--- a/src/Database/Design/Ampersand/Core/AbstractSyntaxTree.hs
+++ b/src/Database/Design/Ampersand/Core/AbstractSyntaxTree.hs
@@ -59,6 +59,7 @@ import Data.List (intercalate,nub,delete)
 import Data.Typeable
 import GHC.Generics (Generic)
 import Data.Hashable
+import Data.Char
 
 fatal :: Int -> String -> a
 fatal = fatalMsg "Core.AbstractSyntaxTree"
@@ -262,7 +263,11 @@ aMarkup2String a = blocks2String (amFormat a) False (amPandoc a)
 data AMeaning = AMeaning { ameaMrk ::[A_Markup]} deriving (Show, Eq, Prelude.Ord)
 
 instance Named Declaration where
-  name d@Sgn{}   = decnm d
+  name d@Sgn{}   = case decnm d of
+                     []  -> fatal 266 "Declaration with an empty name!"
+                     c:cs -> if and [isAlpha c, isLower c]
+                            then c:cs
+                            else show (c:cs)
   name Isn{}     = "I"
   name Vs{}      = "V"
 instance Association Declaration where
@@ -694,7 +699,11 @@ instance Hashable A_Concept where
                         ONE            -> (1::Int)
                       ) 
 instance Named A_Concept where
-  name PlainConcept{cptnm = nm} = nm
+  name PlainConcept{cptnm = nm} = case nm of
+                                   []    -> fatal 703 "Concept with an empty name!"
+                                   (c:_) -> if and [isAlpha c, isUpper c]
+                                            then nm
+                                            else show nm
   name ONE = "ONE"
 
 instance Show A_Concept where

--- a/src/Database/Design/Ampersand/Core/ToMeta.hs
+++ b/src/Database/Design/Ampersand/Core/ToMeta.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 module Database.Design.Ampersand.Core.ToMeta 
-  (toMeta, string2Meta)
+  (toMeta)
 where
 import Database.Design.Ampersand.Misc
 import Database.Design.Ampersand.Core.ParseTree
@@ -15,8 +15,13 @@ toMeta opts =
 string2Meta :: Options -> String -> String
 string2Meta opts str 
               = if metaTablesHaveUnderscore opts 
-                then "__"++str++"__"
+                then show ("__"++unquoted++"__")
                 else str
+  where
+    unquoted
+     | length str < 2 = str
+     | head str == '"' && last str == '"' = reverse . tail . reverse . tail $ str
+     | otherwise = str 
 
 class MakeMeta a where
   makeMeta :: (String -> String) -> a -> a

--- a/src/Database/Design/Ampersand/Core/ToMeta.hs
+++ b/src/Database/Design/Ampersand/Core/ToMeta.hs
@@ -305,10 +305,8 @@ instance MakeMeta TermPrim where
       PNamedR nr      -> PNamedR (makeMeta f nr)
 
 instance MakeMeta P_NamedRel where
-  makeMeta f t
-   = case t of
-      PNamedRel  _ _ Nothing   -> t
-      PNamedRel o s (Just sgn) -> PNamedRel o s (makeMeta f $ Just sgn)
+  makeMeta f (PNamedRel o nm      sgn)
+            = PNamedRel o (f nm) (makeMeta f sgn)
    
 instance MakeMeta Paire where
   makeMeta _ = id

--- a/src/Database/Design/Ampersand/FSpec/Motivations.hs
+++ b/src/Database/Design/Ampersand/FSpec/Motivations.hs
@@ -288,7 +288,7 @@ instance Motivated Declaration where
 --      applyM decl a b =
 --               case decl of
 --                 Sgn{} | null (prL++prM++prR)
---                            -> a++[Space,Str "corresponds",Space,Str "to",Space]++b++[Space,Str "in",Space,Str "relation",Space,Str(decnm decl)]
+--                            -> a++[Space,Str "corresponds",Space,Str "to",Space]++b++[Space,Str "in",Space,Str "relation",Space,Str(name decl)]
 --                       | null prL
 --                            -> a++[Space,Str prM,Space]++b++[Space,Str prR]
 --                       | otherwise

--- a/src/Database/Design/Ampersand/FSpec/ShowMeatGrinder.hs
+++ b/src/Database/Design/Ampersand/FSpec/ShowMeatGrinder.hs
@@ -16,7 +16,6 @@ import Database.Design.Ampersand.FSpec.SQL
 import Database.Design.Ampersand.FSpec.ToFSpec.NormalForms (conjNF)
 import Database.Design.Ampersand.Basics
 import Database.Design.Ampersand.Misc
-import Database.Design.Ampersand.Core.ToMeta
 import Database.Design.Ampersand.FSpec.ShowADL
 import Database.Design.Ampersand.Core.AbstractSyntaxTree
 import Database.Design.Ampersand.Classes.ConceptStructure
@@ -54,7 +53,7 @@ content popKind mType fSpec = unlines
     , "-}"
     , ""
     , "CONTEXT "++show mType++" IN ENGLISH -- (the language is chosen arbitrary, for it is mandatory but irrelevant."]
-    ++ (concat.intersperse  []) (map (lines . showADL' (getOpts fSpec)) (popKind fSpec))
+    ++ (concat.intersperse  []) (map (lines . showADL ) (popKind fSpec))
     ++
     [ ""
     , "ENDCONTEXT"

--- a/src/Database/Design/Ampersand/FSpec/ShowMeatGrinder.hs
+++ b/src/Database/Design/Ampersand/FSpec/ShowMeatGrinder.hs
@@ -31,7 +31,7 @@ data MetaType = Generics | AST deriving (Show)
 
 makeMetaPopulationFile :: MetaType -> FSpec -> (FilePath,String)
 makeMetaPopulationFile mType fSpec
-  = ("MetaPopulationFile"++show mType, content popKind mType fSpec)
+  = ("MetaPopulationFile"++show mType++".adl", content popKind mType fSpec)
     where popKind = case mType of
                       Generics -> generics fSpec
                       AST      -> metaPops fSpec 

--- a/src/Database/Design/Ampersand/FSpec/ShowMeatGrinder.hs
+++ b/src/Database/Design/Ampersand/FSpec/ShowMeatGrinder.hs
@@ -32,7 +32,7 @@ data MetaType = Generics | AST deriving (Show)
 
 makeMetaPopulationFile :: MetaType -> FSpec -> (FilePath,String)
 makeMetaPopulationFile mType fSpec
-  = ("MetaPopulationFile"++show mType++".pop", content popKind mType fSpec)
+  = ("MetaPopulationFile"++show mType, content popKind mType fSpec)
     where popKind = case mType of
                       Generics -> generics fSpec
                       AST      -> metaPops fSpec 
@@ -455,12 +455,11 @@ data Pop = Pop { popName ::String
                }
          | Comment { comment :: String  -- Not-so-nice way to get comments in a list of populations. Since it is local to this module, it is not so bad, I guess...
                    }
-showADL' :: Options -> Pop -> String
-showADL' opts pop = 
-     case pop of
-      Pop{} -> "POPULATION "++ (toVarid . string2Meta opts . popName $ pop)++
-                  " ["++(toConid  . string2Meta opts . popSource $ pop)++"*"++
-                        (toConid  . string2Meta opts . popTarget $ pop)++"] CONTAINS"
+instance ShowADL Pop where
+ showADL pop =
+  case pop of
+      Pop{} -> "POPULATION "++ popName pop++
+                  " ["++popSource pop++" * "++popTarget pop++"] CONTAINS"
               ++
               if null (popPairs pop)
               then "[]"
@@ -470,16 +469,7 @@ showADL' opts pop =
           showContent = map showPaire (popPairs pop)
           showPaire (s,t) = "( "++show s++" , "++show t++" )"
           prepend str = "-- " ++ str
-          toConid str 
-            |isConID str = str
-            |otherwise   = show str
-          toVarid str
-            |isVarID str = str
-            |otherwise   = show str
-          isConID (c:_) = and [isAlpha c, isUpper c]
-          isConID [] = fatal 478 "empty name!"
-          isVarID (c:_) = and [isAlpha c, isLower c]   
-          isVarID [] = fatal 478 "empty name!"
+
 class Unique a => AdlId a where
  uri :: a -> String
  uri = camelCase . uniqueShow True

--- a/src/Database/Design/Ampersand/Input/ADL1/Parser.hs
+++ b/src/Database/Design/Ampersand/Input/ADL1/Parser.hs
@@ -730,7 +730,7 @@ pRelationRef      = PNamedR <$> pNamedRel                                       
                           singl (nm,orig) x  = Patm orig nm x
 
 pNamedRel :: AmpParser P_NamedRel
-pNamedRel = pnamedrel  <$> pVarid_val_pos <*> pMaybe pSign
+pNamedRel = pnamedrel  <$> (pVarid_val_pos <|> pString_val_pos) <*> pMaybe pSign
             where pnamedrel (nm,orig) mSgn = PNamedRel orig nm mSgn
 
 pSign :: AmpParser P_Sign

--- a/src/Database/Design/Ampersand/Input/ADL1/Parser.hs
+++ b/src/Database/Design/Ampersand/Input/ADL1/Parser.hs
@@ -468,7 +468,7 @@ pViewDefLegacy  = vd <$ (pKey "VIEW" <|> pKey "KEY") <*> pLabelProps <*> pConcep
 
 pInterface :: AmpParser P_Interface
 pInterface = lbl <$> (pKey "INTERFACE" *> pADLid_val_pos) <*>
-                     (pMaybe $ pKey "CLASS" *> (pConid <|> pString)) <*> -- the class is an upper-case identifier or a quoted string
+                     (pMaybe $ pKey "CLASS" *> (pConid <|> (show <$> pString))) <*> -- the class is an upper-case identifier or a quoted string
                      (pParams `opt` [])                   <*>       -- a list of expressions, which say which relations are editable within this service.
                                                                     -- either  Prel _ nm
                                                                     --       or  PNamedRel _ nm sgn
@@ -730,8 +730,9 @@ pRelationRef      = PNamedR <$> pNamedRel                                       
                           singl (nm,orig) x  = Patm orig nm x
 
 pNamedRel :: AmpParser P_NamedRel
-pNamedRel = pnamedrel  <$> (pVarid_val_pos <|> pString_val_pos) <*> pMaybe pSign
-            where pnamedrel (nm,orig) mSgn = PNamedRel orig nm mSgn
+pNamedRel = pnamedrel  <$> (pVarid_val_pos <|> mustQuote <$> pString_val_pos) <*> pMaybe pSign
+            where mustQuote (nm, orig) = (show nm, orig)
+                  pnamedrel (nm,orig) mSgn = PNamedRel orig nm mSgn
 
 pSign :: AmpParser P_Sign
 pSign = mkSign <$ pSpec '[' <*> pConceptOneRef <*> pMaybe (pKey "*" *> pConceptOneRef) <* pSpec ']'
@@ -741,7 +742,7 @@ pSign = mkSign <$ pSpec '[' <*> pConceptOneRef <*> pMaybe (pKey "*" *> pConceptO
                         Nothing  -> P_Sign src src
 
 pConceptName ::   AmpParser String
-pConceptName    = pConid <|> pString
+pConceptName    = pConid <|> (show <$> pString)
 
 pConceptRef ::    AmpParser P_Concept
 pConceptRef     = PCpt <$> pConceptName
@@ -750,16 +751,20 @@ pConceptOneRef :: AmpParser P_Concept
 pConceptOneRef  = (P_Singleton <$ pKey "ONE") <|> pConceptRef
 
 pConceptRefPos :: AmpParser (P_Concept, Origin)
-pConceptRefPos     = conid <$> pConid_val_pos   <|>   conid <$> pString_val_pos
-                     where conid :: (String, Origin) ->  (P_Concept, Origin)
-                           conid (c,orig) = (PCpt c, orig)
+pConceptRefPos     = conid False <$> pConid_val_pos   <|>   conid True <$> pString_val_pos
+                     where conid :: Bool -> (String, Origin) ->  (P_Concept, Origin)
+                           conid mustQuote (c,orig) = (PCpt (if mustQuote then show c
+                                                             else c )
+                                                      , orig)
 
 pConceptOneRefPos :: AmpParser (P_Concept, Origin)
-pConceptOneRefPos  = singl <$> pKey_pos "ONE"   <|>   conid <$> pConid_val_pos   <|>   conid <$> pString_val_pos
+pConceptOneRefPos  = singl <$> pKey_pos "ONE"   <|>   conid False <$> pConid_val_pos   <|>   conid True <$> pString_val_pos
                      where singl :: Origin ->  (P_Concept, Origin)
                            singl orig     = (P_Singleton, orig)
-                           conid :: (String, Origin) ->  (P_Concept, Origin)
-                           conid (c,orig) = (PCpt c, orig)
+                           conid :: Bool -> (String, Origin) ->  (P_Concept, Origin)
+                           conid mustQuote (c,orig) = (PCpt (if mustQuote then show c
+                                                             else c )
+                                                      , orig)
 
 --  (SJ) Why does a label have (optional) strings?
 --  (GM) This is a binding mechanism for implementation specific properties, such as SQL/PHP plug,PHP web app,etc.
@@ -785,11 +790,12 @@ pContent          = pSpec '[' *> pListSep pComma pRecord <* pSpec ']'
     pRecordObs = mkPair<$ pSpec '(' <*> pString <* pComma   <*> pString <* pSpec ')' --obsolete
 
 pADLid :: AmpParser String
-pADLid            = pVarid <|> pConid <|> pString
+pADLid            = pVarid <|> pConid <|> (show <$> pString)
 
 pADLid_val_pos :: AmpParser (String, Origin)
-pADLid_val_pos    = pVarid_val_pos <|> pConid_val_pos <|> pString_val_pos
-
+pADLid_val_pos    = pVarid_val_pos <|> pConid_val_pos <|> (mustQuote <$> pString_val_pos)
+          where mustQuote (nm, org) = (show nm, org) 
+          
 pMaybe :: IsParser p s => p a -> p (Maybe a)
 pMaybe p = Just <$> p <|> pSucceed Nothing
 

--- a/src/Database/Design/Ampersand/Output/PredLogic.hs
+++ b/src/Database/Design/Ampersand/Output/PredLogic.hs
@@ -166,7 +166,7 @@ natLangOps l
                apply decl d c =
                   case decl of
                     Sgn{}     -> if null (prL++prM++prR)
-                                   then "$"++d++"$ "++decnm decl++" $"++c++"$"
+                                   then "$"++d++"$ "++name decl++" $"++c++"$"
                                    else prL++" $"++d++"$ "++prM++" $"++c++"$ "++prR
                        where prL = decprL decl
                              prM = decprM decl

--- a/src/Database/Design/Ampersand/Output/ToPandoc/ChapterNatLangReqs.hs
+++ b/src/Database/Design/Ampersand/Output/ToPandoc/ChapterNatLangReqs.hs
@@ -388,7 +388,7 @@ chpNatLangReqs lev fSpec =
   mkSentence isDev decl srcAtom tgtAtom
    = case decl of
        Sgn{} | null (prL++prM++prR)
-                  -> [str' (upCap srcAtom), Space] ++ devShow (source decl) ++ [Str "corresponds",Space,Str "to",Space,str' tgtAtom, Space] ++ devShow (target decl) ++[Str "in",Space,Str "relation",Space,str' (decnm decl),Str "."]
+                  -> [str' (upCap srcAtom), Space] ++ devShow (source decl) ++ [Str "corresponds",Space,Str "to",Space,str' tgtAtom, Space] ++ devShow (target decl) ++[Str "in",Space,Str "relation",Space,str' (name decl),Str "."]
              | otherwise
                   -> leftHalf prL ++ rightHalf
                     where prL = decprL decl


### PR DESCRIPTION
This change enables better handling of stings as names for Concepts and Relations. This is required for enabling meta-tables to have underscores. (part of the meatgrinder)