### PR TITLE
Include xslx

### DIFF
--- a/ampersand.cabal
+++ b/ampersand.cabal
@@ -98,7 +98,8 @@ executable ampersand
                      wl-pprint == 1.1.*,
                      wl-pprint,
                      text >=1.1 && <1.2,
-                     xlsx == 0.1.*
+                     xlsx == 0.1.*,
+                     lens
         
   other-modules:     
                      Database.Design.Ampersand,
@@ -232,7 +233,8 @@ Test-Suite ampersand-test
                      wl-pprint,
                      transformers >=0.3 && <0.4,
                      conduit >=1.2 && <1.3,
-                     xlsx == 0.1.*
+                     xlsx == 0.1.*,
+                     lens
   other-modules:     
                      Database.Design.Ampersand.Misc.Options,
                      Database.Design.Ampersand.Test.Parser.ArbitraryPandoc,

--- a/ampersand.cabal
+++ b/ampersand.cabal
@@ -98,7 +98,8 @@ executable ampersand
                      wl-pprint == 1.1.*,
                      wl-pprint,
                      text >=1.1 && <1.2,
-                     xlsx
+                     xlsx == 0.1.*,
+                     lens
         
   other-modules:     
                      Database.Design.Ampersand,
@@ -202,7 +203,8 @@ executable ampersand
                      Database.Design.Ampersand.Prototype.ValidateEdit,
                      Database.Design.Ampersand.Prototype.ValidateSQL,
                      Paths_ampersand,
-                     Database.Design.Ampersand.Input.Xslx.XLSX
+                     Database.Design.Ampersand.Input.Xslx.XLSX,
+                     Database.Design.Ampersand.Output.Population2Xlsx
 
 
 Test-Suite ampersand-test
@@ -230,7 +232,9 @@ Test-Suite ampersand-test
                      utf8-string,
                      wl-pprint,
                      transformers >=0.3 && <0.4,
-                     conduit >=1.2 && <1.3
+                     conduit >=1.2 && <1.3,
+                     xlsx == 0.1.*,
+                     lens
   other-modules:     
                      Database.Design.Ampersand.Misc.Options,
                      Database.Design.Ampersand.Test.Parser.ArbitraryPandoc,
@@ -239,4 +243,5 @@ Test-Suite ampersand-test
                      Database.Design.Ampersand.Test.Parser.QuickChecks,
                      Database.Design.Ampersand.Test.RunAmpersand,
                      Database.Design.Ampersand.Test.TestScripts,
-                     Database.Design.Ampersand.Input.Xslx.XLSX
+                     Database.Design.Ampersand.Input.Xslx.XLSX,
+                     Database.Design.Ampersand.Output.Population2Xlsx

--- a/ampersand.cabal
+++ b/ampersand.cabal
@@ -98,8 +98,7 @@ executable ampersand
                      wl-pprint == 1.1.*,
                      wl-pprint,
                      text >=1.1 && <1.2,
-                     xlsx == 0.1.*,
-                     lens
+                     xlsx == 0.1.*
         
   other-modules:     
                      Database.Design.Ampersand,
@@ -233,8 +232,7 @@ Test-Suite ampersand-test
                      wl-pprint,
                      transformers >=0.3 && <0.4,
                      conduit >=1.2 && <1.3,
-                     xlsx == 0.1.*,
-                     lens
+                     xlsx == 0.1.*
   other-modules:     
                      Database.Design.Ampersand.Misc.Options,
                      Database.Design.Ampersand.Test.Parser.ArbitraryPandoc,

--- a/ampersand.cabal
+++ b/ampersand.cabal
@@ -100,7 +100,8 @@ executable ampersand
                      text >=1.1 && <1.2,
                      xlsx
         
-  other-modules:     Database.Design.Ampersand,
+  other-modules:     
+                     Database.Design.Ampersand,
                      Database.Design.Ampersand.ADL1,
                      Database.Design.Ampersand.ADL1.Disambiguate,
                      Database.Design.Ampersand.ADL1.ECArule,
@@ -200,7 +201,8 @@ executable ampersand
                      Database.Design.Ampersand.Prototype.StaticFiles_Generated,
                      Database.Design.Ampersand.Prototype.ValidateEdit,
                      Database.Design.Ampersand.Prototype.ValidateSQL,
-                     Paths_ampersand
+                     Paths_ampersand,
+                     Database.Design.Ampersand.Input.Xslx.XLSX
 
 
 Test-Suite ampersand-test
@@ -236,4 +238,5 @@ Test-Suite ampersand-test
                      Database.Design.Ampersand.Test.Parser.ParserTest,
                      Database.Design.Ampersand.Test.Parser.QuickChecks,
                      Database.Design.Ampersand.Test.RunAmpersand,
-                     Database.Design.Ampersand.Test.TestScripts
+                     Database.Design.Ampersand.Test.TestScripts,
+                     Database.Design.Ampersand.Input.Xslx.XLSX

--- a/ampersand.cabal
+++ b/ampersand.cabal
@@ -4,7 +4,7 @@ author:         Stef Joosten
 maintainer:     stef.joosten@ou.nl
 synopsis:       Toolsuite for automated design of business processes.
 description:    You can define your business processes by means of rules, written in Relation Algebra.
-homepage:       http://wiki.ampersand.nl
+homepage:       http://wiki.tarski.nl
 category:       Database Design
 stability:      alpha
 cabal-version:  >= 1.10
@@ -97,12 +97,8 @@ executable ampersand
                      uulib == 0.9.*,
                      wl-pprint == 1.1.*,
                      wl-pprint,
-                     MissingH,
-                     containers >=0.5 && <0.6,
                      text >=1.1 && <1.2,
-                     simple-sql-parser,
-                     pandoc-types,
-                     pandoc
+                     xlsx
         
   other-modules:     Database.Design.Ampersand,
                      Database.Design.Ampersand.ADL1,

--- a/src/Database/Design/Ampersand/Components.hs
+++ b/src/Database/Design/Ampersand/Components.hs
@@ -26,6 +26,8 @@ import Database.Design.Ampersand.FSpec.ShowXMLtiny (showXML)
 import Database.Design.Ampersand.Output
 import Control.Monad
 import System.FilePath
+import System.Time
+import qualified Data.ByteString.Lazy as L
 
 fatal :: Int -> String -> a
 fatal = fatalMsg "Components"
@@ -122,7 +124,20 @@ doGenDocument fSpec =
 -- | This function will generate an Excel workbook file, containing an extract from the FSpec
 doGenFPAExcel :: FSpec -> IO()
 doGenFPAExcel fSpec =
- do { verboseLn (getOpts fSpec) "Generating Excel..."
-    ; writeFile outputFile (showSpreadsheet (fspec2Workbook fSpec))
+ do { verboseLn (getOpts fSpec) "Generating Excel containing FPA..."
+    ; writeFile outputFile $ fspec2FPA_Excel fSpec
     }
    where outputFile = combine (dirOutput (getOpts fSpec)) $ replaceExtension ("FPA_"++baseName (getOpts fSpec)) ".xml"  -- Do not use .xls here, because that generated document contains xml.
+
+doGenPopulationXLSX :: FSpec -> IO()
+doGenPopulationXLSX fSpec =
+ do { verbose (getOpts fSpec) "Generating Excel file containing the population "
+    ; ct <- getClockTime
+    ; L.writeFile outputFile $ fSpec2PopulationXlsx ct fSpec
+    ; Prelude.putStrLn $ "Generated file: " ++ outputFile
+    }
+   where outputFile = combine (dirOutput (getOpts fSpec)) $ replaceExtension (baseName (getOpts fSpec)) ".generated.pop"
+
+    
+   
+   

--- a/src/Database/Design/Ampersand/Components.hs
+++ b/src/Database/Design/Ampersand/Components.hs
@@ -42,6 +42,7 @@ generateAmpersandOutput fSpec =
     ; when (export2adl (getOpts fSpec))  $ doGenADL      fSpec
     ; when (genFSpec (getOpts fSpec))    $ doGenDocument fSpec
     ; when (genFPAExcel (getOpts fSpec)) $ doGenFPAExcel fSpec
+    ; when (genPOPExcel (getOpts fSpec)) $ doGenPopsXLSX fSpec
     ; when (proofs (getOpts fSpec))      $ doGenProofs   fSpec
     --; Prelude.putStrLn $ "Declared rules:\n" ++ show (map showADL $ vrules fSpec)
     --; Prelude.putStrLn $ "Generated rules:\n" ++ show (map showADL $ grules fSpec)
@@ -129,14 +130,14 @@ doGenFPAExcel fSpec =
     }
    where outputFile = combine (dirOutput (getOpts fSpec)) $ replaceExtension ("FPA_"++baseName (getOpts fSpec)) ".xml"  -- Do not use .xls here, because that generated document contains xml.
 
-doGenPopulationXLSX :: FSpec -> IO()
-doGenPopulationXLSX fSpec =
- do { verbose (getOpts fSpec) "Generating Excel file containing the population "
+doGenPopsXLSX :: FSpec -> IO()
+doGenPopsXLSX fSpec =
+ do { verboseLn (getOpts fSpec) "Generating .xlsx file containing the population "
     ; ct <- getClockTime
     ; L.writeFile outputFile $ fSpec2PopulationXlsx ct fSpec
     ; Prelude.putStrLn $ "Generated file: " ++ outputFile
     }
-   where outputFile = combine (dirOutput (getOpts fSpec)) $ replaceExtension (baseName (getOpts fSpec)) ".generated.pop"
+   where outputFile = combine (dirOutput (getOpts fSpec)) $ replaceExtension (baseName (getOpts fSpec)++ "_generated_pop") ".xlsx"
 
     
    

--- a/src/Database/Design/Ampersand/Core/ParseTree.hs
+++ b/src/Database/Design/Ampersand/Core/ParseTree.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 module Database.Design.Ampersand.Core.ParseTree (
-     P_Context(..), mergeContexts
+     P_Context(..), mergeContexts, mkContextOfPopsOnly
    , Meta(..)
    , MetaObj(..)
    , P_RoleRelation(..)
@@ -680,6 +680,29 @@ mergeContexts ctx1 ctx2 =
       }
     where contexts = [ctx1,ctx2]
 
+mkContextOfPopsOnly :: [P_Population] -> P_Context
+mkContextOfPopsOnly pops = 
+  PCtx{ ctx_nm     = ""
+      , ctx_pos    = []
+      , ctx_lang   = fatal 686 "No language because of excel import hack. Please report this as a bug"
+      , ctx_markup = Nothing
+      , ctx_thms   = []
+      , ctx_pats   = []
+      , ctx_rs     = []
+      , ctx_ds     = []
+      , ctx_cs     = []
+      , ctx_ks     = []
+      , ctx_rrules = []
+      , ctx_rrels  = []
+      , ctx_vs     = []
+      , ctx_gs     = []
+      , ctx_ifcs   = []
+      , ctx_ps     = []
+      , ctx_pops   = pops
+      , ctx_sql    = []
+      , ctx_php    = []
+      , ctx_metas  = []
+      }
 -- | Left-biased choice on maybes
 orElse :: Maybe a -> Maybe a -> Maybe a
 x `orElse` y = case x of

--- a/src/Database/Design/Ampersand/FSpec/ToFSpec/ADL2Plug.hs
+++ b/src/Database/Design/Ampersand/FSpec/ToFSpec/ADL2Plug.hs
@@ -206,7 +206,7 @@ rel2fld context
        
        mkColumnName expr = mkColumnName' False expr
          where  mkColumnName' isFlipped (EFlp x) = mkColumnName' (not isFlipped) x
-                mkColumnName' isFlipped (EDcD d) = (if isFlipped then "src" else "tgt")++"_"++(unquote . name) d
+                mkColumnName' isFlipped (EDcD d) = (if isFlipped then "src" else "tgt")++"_"++(unquote . name) d  --TODO: This has to be made more generic, to enable writing of populations from tables. (Excell spreadsheets)
                 mkColumnName' _         (EDcI c) = (unquote . name) c
                 mkColumnName' _ rel = fatal 162 ( "Unexpected relation found:\n"++
                                                   intercalate "\n  "

--- a/src/Database/Design/Ampersand/Input/Parsing.hs
+++ b/src/Database/Design/Ampersand/Input/Parsing.hs
@@ -15,6 +15,7 @@ import Database.Design.Ampersand.Basics
 import Database.Design.Ampersand.Input.ADL1.CtxError
 import Database.Design.Ampersand.Input.ADL1.Lexer
 import Database.Design.Ampersand.Input.ADL1.Parser
+import Database.Design.Ampersand.Core.ParseTree (mkContextOfPopsOnly)
 import Database.Design.Ampersand.Misc
 import Prelude hiding (putStrLn, writeFile) -- make sure everything is UTF8
 import System.Directory
@@ -50,7 +51,7 @@ parseSingleADL opts filePath
  | extension == ".xlsx" = 
      do { verboseLn opts $ "Reading Excel populations from " ++ filePath
         ; popFromExcel <- parseXlsxFile opts filePath
-        ; return ((\ctx -> (ctx,[])) <$> popFromExcel)  -- Excel file cannot contain include files
+        ; return ((\pops -> (mkContextOfPopsOnly pops,[])) <$> popFromExcel)  -- Excel file cannot contain include files
         }
  | otherwise =   
      do { verboseLn opts $ "Reading file " ++ filePath

--- a/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
+++ b/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Database.Design.Ampersand.Input.Xslx.XLSX 
   (parseXlsxFile)
 where
@@ -6,19 +7,173 @@ import Database.Design.Ampersand.Misc
 import Prelude hiding (putStrLn, writeFile) -- make sure everything is UTF8
 import Database.Design.Ampersand.Input.ADL1.CtxError
 import Database.Design.Ampersand.ADL1
-
 import Codec.Xlsx
 import qualified Data.ByteString.Lazy as L
---import Control.Lens
+import Control.Lens
+import qualified Data.Text as T
+import qualified Data.Map as M 
+import Data.Maybe
+import Data.Char
 
 fatal :: Int -> String -> a
 fatal = fatalMsg "XLSX"
 
-parseXlsxFile :: Options -> FilePath -> IO (Guarded P_Context)
+parseXlsxFile :: Options -> FilePath -> IO (Guarded [P_Population])
 parseXlsxFile _ filePath = 
   do bytestr <- L.readFile filePath
      return . xlsx2pContext . toXlsx $ bytestr
 
-xlsx2pContext :: Xlsx -> Guarded P_Context
-xlsx2pContext xlsx = fatal 14 "INCLUDE Excel files comming soon."
+xlsx2pContext :: Xlsx -> Guarded [P_Population]
+xlsx2pContext xlsx 
+  = case Prelude.concatMap theSheetCellsForTable (xlsx ^. xlSheets . to M.toList) of --
+                       [] -> fatal 28 "INCLUDE Excel files comming soon."
+                       xs -> fatal 29 "INCLUDE Excel files comming soon."
 
+data SheetCellsForTable 
+       = Mapping{ theSheetName :: String
+                , theCellMap   :: CellMap
+                , headerRowNrs :: [Int]
+                , popRowNrs    :: [Int]
+                , colNrs       :: [Int]
+                }
+
+toPops :: FilePath -> SheetCellsForTable -> [P_Population]
+toPops file x = map popForColumn (colNrs x)
+  where
+    popForColumn :: Int -> P_Population
+    popForColumn i 
+      | i  == 1  
+         = P_CptPopu { p_orig = originOfCell (headerRowNrs x !! (2-1), colNrs x !! (1-1))
+                     , p_cnme = case value (headerRowNrs x !! (2-1),i) of
+                         Just (CellText t) -> T.unpack t
+                         _ -> fatal 49 "No valid string fond. This should have been checked before" 
+                     , p_popas = map T.unpack [] 
+                     }
+                             
+      | otherwise = fatal 47 "TODO"
+    originOfCell :: (Int,Int) -- (row number,col number)
+                 -> Origin
+    originOfCell (r,c) 
+      = Origin $ file ++", sheet: "++theSheetName x++", Cell ("++show r++","++show c++")" --TODO: Make separate Origin constructor for this 
+
+    value :: (Int,Int) -> Maybe CellValue
+    value k = (theCellMap x) ^? ix k . cellValue . _Just
+
+
+
+theSheetCellsForTable :: (T.Text,Worksheet) -> [SheetCellsForTable]
+theSheetCellsForTable (sheetName,ws) 
+  = trace (T.unpack sheetName ++": "++show tableStarters) $ 
+     catMaybes [mapping i | i <- [0..(Prelude.length tableStarters) - 1]]
+  where
+    tableStarters :: [(Int,Int)]
+    tableStarters = Prelude.filter isStartOfTable $ M.keys cm  
+      where cm = ws  ^. wsCells
+            ks = M.keys cm
+            isStartOfTable :: (Int,Int) -> Bool
+            isStartOfTable k@(r,c) 
+              = c == 1 && case  value k of
+                             Just (CellText t) -> (not . T.null ) t && T.head t == '[' && T.last t == ']'
+                             _  -> False
+    value :: (Int,Int) -> Maybe CellValue
+    value k = (ws  ^. wsCells) ^? ix k . cellValue . _Just
+    mapping :: Int -> Maybe SheetCellsForTable
+    mapping indexInTableStarters 
+     | length headerRows /= 2 = Nothing  -- Because there are not enough header rows
+     | otherwise
+     = --trace (show ((r1,c1),theRows,theCols)
+       --       ) $
+        Just Mapping { theSheetName = T.unpack sheetName
+                     , theCellMap   = ws  ^. wsCells
+                     , headerRowNrs = headerRows
+                     , popRowNrs    = populationRows
+                     , colNrs       = theCols
+                     }
+     where
+       (r1,_{-c1-}) = tableStarters !! indexInTableStarters 
+       maxRowOfWorksheet = Prelude.maximum (Prelude.map fst (M.keys (ws  ^. wsCells)))
+       maxColOfWorksheet = Prelude.maximum (Prelude.map snd (M.keys (ws  ^. wsCells)))
+       maxRows = (map fst tableStarters++[maxRowOfWorksheet])!!(indexInTableStarters+1)-r1
+       headerRows = map (+ r1) $ filter isProperRow [1,2]
+       populationRows = filter isProperRow [length headerRows+1..maxRows]
+       isProperRow :: Int -> Bool
+       isProperRow i
+          | i == 1 = True -- The first row was recognized as tableStarter
+          | i == 2 = isProperConceptName(r1-1+i,1)
+          | otherwise = notEmpty (r1-1+i,1)
+       notEmpty k
+          = case value k of
+            Just (CellText t) -> (not . T.null) t
+            _ -> False
+       theCols = filter isProperCol [1..maxColOfWorksheet]
+       isProperCol :: Int -> Bool
+       isProperCol i
+          | i == 1    = isProperConceptName (r1+1,i)
+          | otherwise = isProperConceptName (r1+1,i) && isProperRelName(r1,i)
+       isProperConceptName k 
+         = case value k of
+            Just (CellText t) -> (not . T.null) t && isUpper(T.head t)
+            _ -> False
+       isProperRelName k 
+         = case value k of
+            Just (CellText t) -> (not . T.null) t && isLower(T.head t)
+            _ -> False
+               
+   
+
+
+type TableContent = [[Cell]]
+extractTableContents :: Xlsx -> [TableContent]
+extractTableContents xlsx =  Prelude.concatMap tablesOfSheet' theSheets
+  where 
+        theSheets :: [(T.Text,Worksheet)]
+        theSheets = xlsx ^. xlSheets . to M.toList   
+        cellmap :: (T.Text,Worksheet) -> CellMap
+        cellmap (t,ws) = ws  ^. wsCells
+        
+
+
+tablesOfSheet' :: (T.Text,Worksheet) -> [TableContent]
+tablesOfSheet' (t,ws) = trace aap []
+   where aap = T.unpack . T.intercalate ("\n  ") . Prelude.map T.pack $ 
+                  [ "Sheet: "++T.unpack t
+               --   , "columns: " ++ myshow (ws ^? wsColumns )
+               --   , "rowprops:"++ show (ws ^? wsRowPropertiesMap  )
+                    , "cells: " ++ showCells (ws ^? wsCells  )
+               --   , "merges: " ++ show (ws ^? wsMerges  )
+                  ]
+         myshow :: Maybe [ColumnsWidth] -> String
+         myshow Nothing = ""
+         myshow (Just cws) = Prelude.concatMap show1 cws 
+         show1 (ColumnsWidth min max width style) =  show (min,max,width,style)  
+         colums = ws ^? wsCells  
+         showCells :: Maybe CellMap -> String
+         showCells (Just cm)= "Range: "++show (firstRow ks,lastRow ks)++ " - "++show ( firstCol ks,lastCol ks)
+                                       ++show ("starters: "++show (tableStarters cm))
+                                       ++Prelude.concat ["\nKeys vanaf start "++show start++" t/m "++show eind++": \n  "
+                                                 -- ++show ks
+                                                |(start,eind) <-
+                                                     [(rij !! i, rij !! (i+1))| i <- [0..Prelude.length rij - 1]]]
+                                                
+           where ks = M.keys cm
+                 rij = tableStarters cm++ [(lastRow ks,1)]
+         firstRow ks= Prelude.minimum (Prelude.map fst ks)
+         lastRow  ks= Prelude.maximum (Prelude.map fst ks)
+         firstCol ks= Prelude.minimum (Prelude.map snd ks)
+         lastCol  ks= Prelude.maximum (Prelude.map snd ks)
+         tableStarters :: CellMap -> [(Int,Int)]
+         tableStarters cm = Prelude.filter isStartOfTable $ M.keys cm  
+           where ks = M.keys cm
+                 isStartOfTable :: (Int,Int) -> Bool
+                 isStartOfTable k@(r,c) 
+                   = c == 1 && case  value k of
+                                  Just (CellText t) -> (not . T.null ) t && T.head t == '[' && T.last t == ']'
+                                  _  -> False
+                 value :: (Int,Int) -> Maybe CellValue
+                 value k = cm ^? ix k . cellValue . _Just
+         tableWidth :: (Int,Int) -> Int
+         tableWidth (r,c) = 1 -- length noot
+           where -- noot = Prelude.takeWhile (isJust) ((fmap (lookup k          
+                keysOfRow = Prelude.filter (\k -> r == fst k) (M.keys cm)
+                cm = ws ^. wsCells  
+         

--- a/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
+++ b/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
@@ -22,13 +22,12 @@ parseXlsxFile :: Options -> FilePath -> IO (Guarded [P_Population])
 parseXlsxFile _ filePath = 
   do bytestr <- L.readFile filePath
      return . xlsx2pContext . toXlsx $ bytestr
-
-xlsx2pContext :: Xlsx -> Guarded [P_Population]
-xlsx2pContext xlsx 
-  = case Prelude.concatMap theSheetCellsForTable (xlsx ^. xlSheets . to M.toList) of --
-                       [] -> fatal 28 "INCLUDE Excel files comming soon."
-                       xs -> fatal 29 "INCLUDE Excel files comming soon."
-
+ where
+  xlsx2pContext :: Xlsx -> Guarded [P_Population]
+  xlsx2pContext xlsx 
+    = Checked $ concatMap (toPops filePath) $
+         Prelude.concatMap theSheetCellsForTable (xlsx ^. xlSheets . to M.toList)
+      
 data SheetCellsForTable 
        = Mapping{ theSheetName :: String
                 , theCellMap   :: CellMap
@@ -36,29 +35,87 @@ data SheetCellsForTable
                 , popRowNrs    :: [Int]
                 , colNrs       :: [Int]
                 }
-
+showMapping :: SheetCellsForTable -> String
+showMapping x 
+ = unlines $
+    [ "Sheet       : "++theSheetName x
+    , "headerRowNrs: "++show (headerRowNrs x)
+    , "popRowNrs   : "++show (popRowNrs x)
+    , "colNrs      : "++show (colNrs x)
+    ]  
 toPops :: FilePath -> SheetCellsForTable -> [P_Population]
-toPops file x = map popForColumn (colNrs x)
+toPops file x = trace (showMapping x) $
+                map popForColumn (colNrs x)
   where
     popForColumn :: Int -> P_Population
     popForColumn i 
       | i  == 1  
-         = P_CptPopu { p_orig = originOfCell (headerRowNrs x !! (2-1), colNrs x !! (1-1))
-                     , p_cnme = case value (headerRowNrs x !! (2-1),i) of
-                         Just (CellText t) -> T.unpack t
-                         _ -> fatal 49 "No valid string fond. This should have been checked before" 
-                     , p_popas = map T.unpack [] 
+        = trace ("Starting for colunm: "++show i) 
+           P_CptPopu { p_orig = popOrigin
+                     , p_cnme = sourceConceptName 
+                     , p_popas = map T.unpack [fromMaybe (fatal 49 "this value should be present")
+                                                         (case value(row,i) of
+                                                           Just (CellText t) -> Just t
+                                                           _ -> Nothing)
+                                              | row <- popRowNrs x] 
                      }
-                             
-      | otherwise = fatal 47 "TODO"
+      | otherwise
+        = trace ("Starting for colunm: "++show i) $
+          trace (show(conceptNamesRow,relNamesRow,sourceCol,targetCol))$
+           (case mTargetConceptName of
+             Just tCptName 
+                -> P_TRelPop { p_orig = popOrigin
+                             , p_rnme = relName
+                             , p_type = P_Sign {pSrc = PCpt sourceConceptName
+                                               ,pTgt = PCpt tCptName
+                                               }
+                             , p_popps = thePairs}
+             Nothing
+                -> P_RelPopu { p_orig = popOrigin
+                             , p_rnme = relName
+                             , p_popps = thePairs}
+           )
+     where                             
+       popOrigin :: Origin
+       popOrigin = originOfCell (relNamesRow, targetCol)
+       conceptNamesRow = headerRowNrs x !! 1
+       relNamesRow     = headerRowNrs x !! 0
+       sourceCol       = colNrs x !! 0
+       targetCol       = i 
+       sourceConceptName :: String
+       sourceConceptName 
+          = case value (conceptNamesRow,sourceCol) of
+                Just (CellText t) -> T.unpack t
+                _ -> fatal 66 "No valid source conceptname found. This should have been checked before"
+       mTargetConceptName :: Maybe String
+       mTargetConceptName 
+          = case value (conceptNamesRow,targetCol) of
+                Just (CellText t) -> Just (T.unpack t)
+                _ -> Nothing
+       relName :: String
+       relName 
+          = case value (relNamesRow,targetCol) of
+                Just (CellText t) -> T.unpack t
+                _ -> fatal 87 $ "No valid relation name found. This should have been checked before" ++show (relNamesRow,targetCol)
+       thePairs = catMaybes (map pairAtRow (popRowNrs x))
+       pairAtRow :: Int -> Maybe Paire
+       pairAtRow r = case (value (r,sourceCol)
+                          ,value (r,targetCol)
+                          ) of
+                       (Just s,Just t) -> Just $ mkPair (cellToString s) (cellToString t)
+                       _ -> Nothing
+       cellToString :: CellValue -> String
+       cellToString cv = case cv of
+                          CellText t -> T.unpack t
+                          CellDouble d -> show d
+                          CellBool b -> show b 
     originOfCell :: (Int,Int) -- (row number,col number)
                  -> Origin
     originOfCell (r,c) 
-      = Origin $ file ++", sheet: "++theSheetName x++", Cell ("++show r++","++show c++")" --TODO: Make separate Origin constructor for this 
+      = Origin $ file ++",\n  Sheet: "++theSheetName x++", Cell ("++show r++","++show c++")" --TODO: Make separate Origin constructor for this 
 
     value :: (Int,Int) -> Maybe CellValue
     value k = (theCellMap x) ^? ix k . cellValue . _Just
-
 
 
 theSheetCellsForTable :: (T.Text,Worksheet) -> [SheetCellsForTable]
@@ -93,8 +150,8 @@ theSheetCellsForTable (sheetName,ws)
        (r1,_{-c1-}) = tableStarters !! indexInTableStarters 
        maxRowOfWorksheet = Prelude.maximum (Prelude.map fst (M.keys (ws  ^. wsCells)))
        maxColOfWorksheet = Prelude.maximum (Prelude.map snd (M.keys (ws  ^. wsCells)))
-       maxRows = (map fst tableStarters++[maxRowOfWorksheet])!!(indexInTableStarters+1)-r1
-       headerRows = map (+ r1) $ filter isProperRow [1,2]
+       maxRows = ((map fst tableStarters++[maxRowOfWorksheet])!!(indexInTableStarters+1))-r1+1
+       headerRows = map (+ (r1-1)) $ filter isProperRow [1,2]
        populationRows = filter isProperRow [length headerRows+1..maxRows]
        isProperRow :: Int -> Bool
        isProperRow i

--- a/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
+++ b/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
@@ -35,23 +35,21 @@ data SheetCellsForTable
                 , popRowNrs    :: [Int]
                 , colNrs       :: [Int]
                 }
-showMapping :: SheetCellsForTable -> String
-showMapping x 
- = unlines $
-    [ "Sheet       : "++theSheetName x
-    , "headerRowNrs: "++show (headerRowNrs x)
-    , "popRowNrs   : "++show (popRowNrs x)
-    , "colNrs      : "++show (colNrs x)
-    ]  
+instance Show SheetCellsForTable where  --for debugging only
+  show x 
+   = unlines $
+      [ "Sheet       : "++theSheetName x
+      , "headerRowNrs: "++show (headerRowNrs x)
+      , "popRowNrs   : "++show (popRowNrs x)
+      , "colNrs      : "++show (colNrs x)
+      ]  
 toPops :: FilePath -> SheetCellsForTable -> [P_Population]
-toPops file x = trace (showMapping x) $
-                map popForColumn (colNrs x)
+toPops file x = map popForColumn (colNrs x)
   where
     popForColumn :: Int -> P_Population
     popForColumn i 
       | i  == 1  
-        = trace ("Starting for colunm: "++show i) 
-           P_CptPopu { p_orig = popOrigin
+        =  P_CptPopu { p_orig = popOrigin
                      , p_cnme = sourceConceptName 
                      , p_popas = map T.unpack [fromMaybe (fatal 49 "this value should be present")
                                                          (case value(row,i) of
@@ -60,9 +58,7 @@ toPops file x = trace (showMapping x) $
                                               | row <- popRowNrs x] 
                      }
       | otherwise
-        = trace ("Starting for colunm: "++show i) $
-          trace (show(conceptNamesRow,relNamesRow,sourceCol,targetCol))$
-           (case mTargetConceptName of
+        =  (case mTargetConceptName of
              Just tCptName 
                 -> P_TRelPop { p_orig = popOrigin
                              , p_rnme = relName
@@ -120,27 +116,22 @@ toPops file x = trace (showMapping x) $
 
 theSheetCellsForTable :: (T.Text,Worksheet) -> [SheetCellsForTable]
 theSheetCellsForTable (sheetName,ws) 
-  = trace (T.unpack sheetName ++": "++show tableStarters) $ 
-     catMaybes [mapping i | i <- [0..(Prelude.length tableStarters) - 1]]
+  =  catMaybes [theMapping i | i <- [0..(Prelude.length tableStarters) - 1]]
   where
     tableStarters :: [(Int,Int)]
-    tableStarters = Prelude.filter isStartOfTable $ M.keys cm  
-      where cm = ws  ^. wsCells
-            ks = M.keys cm
-            isStartOfTable :: (Int,Int) -> Bool
-            isStartOfTable k@(r,c) 
-              = c == 1 && case  value k of
+    tableStarters = Prelude.filter isStartOfTable $ M.keys (ws  ^. wsCells)  
+      where isStartOfTable :: (Int,Int) -> Bool
+            isStartOfTable k 
+              = (snd k) == 1 && case  value k of
                              Just (CellText t) -> (not . T.null ) t && T.head t == '[' && T.last t == ']'
                              _  -> False
     value :: (Int,Int) -> Maybe CellValue
     value k = (ws  ^. wsCells) ^? ix k . cellValue . _Just
-    mapping :: Int -> Maybe SheetCellsForTable
-    mapping indexInTableStarters 
+    theMapping :: Int -> Maybe SheetCellsForTable
+    theMapping indexInTableStarters 
      | length headerRows /= 2 = Nothing  -- Because there are not enough header rows
      | otherwise
-     = --trace (show ((r1,c1),theRows,theCols)
-       --       ) $
-        Just Mapping { theSheetName = T.unpack sheetName
+     =  Just Mapping { theSheetName = T.unpack sheetName
                      , theCellMap   = ws  ^. wsCells
                      , headerRowNrs = headerRows
                      , popRowNrs    = populationRows
@@ -178,59 +169,4 @@ theSheetCellsForTable (sheetName,ws)
                
    
 
-
-type TableContent = [[Cell]]
-extractTableContents :: Xlsx -> [TableContent]
-extractTableContents xlsx =  Prelude.concatMap tablesOfSheet' theSheets
-  where 
-        theSheets :: [(T.Text,Worksheet)]
-        theSheets = xlsx ^. xlSheets . to M.toList   
-        cellmap :: (T.Text,Worksheet) -> CellMap
-        cellmap (t,ws) = ws  ^. wsCells
-        
-
-
-tablesOfSheet' :: (T.Text,Worksheet) -> [TableContent]
-tablesOfSheet' (t,ws) = trace aap []
-   where aap = T.unpack . T.intercalate ("\n  ") . Prelude.map T.pack $ 
-                  [ "Sheet: "++T.unpack t
-               --   , "columns: " ++ myshow (ws ^? wsColumns )
-               --   , "rowprops:"++ show (ws ^? wsRowPropertiesMap  )
-                    , "cells: " ++ showCells (ws ^? wsCells  )
-               --   , "merges: " ++ show (ws ^? wsMerges  )
-                  ]
-         myshow :: Maybe [ColumnsWidth] -> String
-         myshow Nothing = ""
-         myshow (Just cws) = Prelude.concatMap show1 cws 
-         show1 (ColumnsWidth min max width style) =  show (min,max,width,style)  
-         colums = ws ^? wsCells  
-         showCells :: Maybe CellMap -> String
-         showCells (Just cm)= "Range: "++show (firstRow ks,lastRow ks)++ " - "++show ( firstCol ks,lastCol ks)
-                                       ++show ("starters: "++show (tableStarters cm))
-                                       ++Prelude.concat ["\nKeys vanaf start "++show start++" t/m "++show eind++": \n  "
-                                                 -- ++show ks
-                                                |(start,eind) <-
-                                                     [(rij !! i, rij !! (i+1))| i <- [0..Prelude.length rij - 1]]]
-                                                
-           where ks = M.keys cm
-                 rij = tableStarters cm++ [(lastRow ks,1)]
-         firstRow ks= Prelude.minimum (Prelude.map fst ks)
-         lastRow  ks= Prelude.maximum (Prelude.map fst ks)
-         firstCol ks= Prelude.minimum (Prelude.map snd ks)
-         lastCol  ks= Prelude.maximum (Prelude.map snd ks)
-         tableStarters :: CellMap -> [(Int,Int)]
-         tableStarters cm = Prelude.filter isStartOfTable $ M.keys cm  
-           where ks = M.keys cm
-                 isStartOfTable :: (Int,Int) -> Bool
-                 isStartOfTable k@(r,c) 
-                   = c == 1 && case  value k of
-                                  Just (CellText t) -> (not . T.null ) t && T.head t == '[' && T.last t == ']'
-                                  _  -> False
-                 value :: (Int,Int) -> Maybe CellValue
-                 value k = cm ^? ix k . cellValue . _Just
-         tableWidth :: (Int,Int) -> Int
-         tableWidth (r,c) = 1 -- length noot
-           where -- noot = Prelude.takeWhile (isJust) ((fmap (lookup k          
-                keysOfRow = Prelude.filter (\k -> r == fst k) (M.keys cm)
-                cm = ws ^. wsCells  
          

--- a/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
+++ b/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
@@ -7,8 +7,18 @@ import Prelude hiding (putStrLn, writeFile) -- make sure everything is UTF8
 import Database.Design.Ampersand.Input.ADL1.CtxError
 import Database.Design.Ampersand.ADL1
 
+import Codec.Xlsx
+import qualified Data.ByteString.Lazy as L
+--import Control.Lens
+
 fatal :: Int -> String -> a
 fatal = fatalMsg "Parsing"
 
 parseXlsxFile :: Options -> FilePath -> IO (Guarded P_Context)
-parseXlsxFile _ _ = fatal 14 "INCLUDE Excel files comming soon."
+parseXlsxFile _ filePath = 
+  do bytestr <- L.readFile filePath
+     return . xlsx2pContext . toXlsx $ bytestr
+
+xlsx2pContext :: Xlsx -> Guarded P_Context
+xlsx2pContext xlsx = fatal 14 "INCLUDE Excel files comming soon."
+

--- a/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
+++ b/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
@@ -1,0 +1,14 @@
+module Database.Design.Ampersand.Input.Xslx.XLSX 
+  (parseXlsxFile)
+where
+import Database.Design.Ampersand.Basics
+import Database.Design.Ampersand.Misc
+import Prelude hiding (putStrLn, writeFile) -- make sure everything is UTF8
+import Database.Design.Ampersand.Input.ADL1.CtxError
+import Database.Design.Ampersand.ADL1
+
+fatal :: Int -> String -> a
+fatal = fatalMsg "Parsing"
+
+parseXlsxFile :: Options -> FilePath -> IO (Guarded P_Context)
+parseXlsxFile _ _ = fatal 14 "INCLUDE Excel files comming soon."

--- a/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
+++ b/src/Database/Design/Ampersand/Input/Xslx/XLSX.hs
@@ -12,7 +12,7 @@ import qualified Data.ByteString.Lazy as L
 --import Control.Lens
 
 fatal :: Int -> String -> a
-fatal = fatalMsg "Parsing"
+fatal = fatalMsg "XLSX"
 
 parseXlsxFile :: Options -> FilePath -> IO (Guarded P_Context)
 parseXlsxFile _ filePath = 

--- a/src/Database/Design/Ampersand/Misc/Options.hs
+++ b/src/Database/Design/Ampersand/Misc/Options.hs
@@ -65,6 +65,7 @@ data Options = Options { showVersion :: Bool
                        , genUML :: Bool   -- Generate a UML 2.0 data model
                        , genFPAChap :: Bool   -- Generate Function Point Analysis chapter
                        , genFPAExcel :: Bool   -- Generate an Excel workbook containing Function Point Analysis
+                       , genPOPExcel :: Bool   -- Generate an .xmlx file containing the populations 
                        , genStaticFiles :: Bool-- Generate the static files into the prototype
                        , genBericht :: Bool
                        , language :: Maybe Lang  -- The language in which the user wants the documentation to be printed.
@@ -167,6 +168,7 @@ getOptions =
                       , genFPAChap    = False
                       , genFPAExcel   = False
                       , genStaticFiles= True
+                      , genPOPExcel   = False
                       , genBericht    = False
                       , language      = Nothing
                       , progrName     = progName
@@ -410,10 +412,14 @@ options = [ (Option ['v']   ["version"]
                (NoArg (\opts -> return opts{genFPAChap = True}))
                "Generate Function Point Analysis chapter."
             , Hidden)
-          , (Option []        ["excel"]
+          , (Option []        ["fpa-excel"]
                (NoArg (\opts -> return opts{genFPAExcel = True}))
                "Generate an Excel workbook (FPA_<filename>.xml)."
             , Hidden)
+          , (Option []        ["pop-xlsx"]
+               (NoArg (\opts -> return opts{genPOPExcel = True}))
+               "Generate an .xmlx file containing the populations of your script."
+            , Public) 
           , (Option []        ["bericht"]
                (NoArg (\opts -> return opts{genBericht = True}))
                "Generate definitions for 'berichten' (specific to INDOORS project)."

--- a/src/Database/Design/Ampersand/Output.hs
+++ b/src/Database/Design/Ampersand/Output.hs
@@ -2,8 +2,10 @@ module Database.Design.Ampersand.Output
     ( module Database.Design.Ampersand.Output.FSpec2Pandoc
     , module Database.Design.Ampersand.Output.PandocAux
     , module Database.Design.Ampersand.Output.FSpec2Excel
+    , module Database.Design.Ampersand.Output.Population2Xlsx
     ) where
 import Database.Design.Ampersand.Output.FSpec2Pandoc
        (fSpec2Pandoc)
 import Database.Design.Ampersand.Output.PandocAux (writepandoc)
 import Database.Design.Ampersand.Output.FSpec2Excel
+import Database.Design.Ampersand.Output.Population2Xlsx

--- a/src/Database/Design/Ampersand/Output/FSpec2Excel.hs
+++ b/src/Database/Design/Ampersand/Output/FSpec2Excel.hs
@@ -1,4 +1,4 @@
-module Database.Design.Ampersand.Output.FSpec2Excel (fspec2Workbook,showSpreadsheet)
+module Database.Design.Ampersand.Output.FSpec2Excel (fspec2FPA_Excel)
 where
 import Text.XML.SpreadsheetML.Builder
 import Text.XML.SpreadsheetML.Types
@@ -10,7 +10,12 @@ import Database.Design.Ampersand.FSpec.FPA
 import Database.Design.Ampersand.Basics
 import Data.Maybe
 
+-- TODO: Get rid of package SpreadsheetML. Use http://hackage.haskell.org/package/xlsx (Reason: SpreadsheetML doesn.t have a writer. xlsx package does.
+
 -- NOTE: this code was refactored to support the new FPA module, but has not been tested yet.
+
+fspec2FPA_Excel :: FSpec -> String
+fspec2FPA_Excel = showSpreadsheet . fspec2Workbook
 
 fspec2Workbook :: FSpec -> Workbook
 fspec2Workbook fSpec =

--- a/src/Database/Design/Ampersand/Output/Population2Xlsx.hs
+++ b/src/Database/Design/Ampersand/Output/Population2Xlsx.hs
@@ -9,7 +9,7 @@ import System.Time
 import qualified Data.Map as M
 import Codec.Xlsx
 import qualified Data.ByteString.Lazy as L
-import Data.Text hiding (zip, transpose)
+import qualified Data.Text as T
 import Data.Maybe
 import Data.List
 
@@ -21,15 +21,14 @@ fSpec2PopulationXlsx ct fSpec =
                
      
 
-plugs2Sheets :: FSpec -> M.Map Text Worksheet
+plugs2Sheets :: FSpec -> M.Map T.Text Worksheet
 plugs2Sheets fSpec = M.fromList . catMaybes . Prelude.map plug2sheet $ plugInfos fSpec
   where
-    plug2sheet :: PlugInfo -> Maybe (Text, Worksheet)
+    plug2sheet :: PlugInfo -> Maybe (T.Text, Worksheet)
     plug2sheet ExternalPlug{} = Nothing  -- Not supported at present
-    plug2sheet (InternalPlug plug) = fmap (\x -> (pack (name plug),x)) sheet
+    plug2sheet (InternalPlug plug) = fmap (\x -> (T.pack (name plug),x)) sheet
       where 
        sheet :: Maybe Worksheet
-       --sheet = def & cellValueAt (1,1) ?~ CellText (pack ("["++name plug++"'s]"))
        sheet = case matrix of
                  Nothing -> Nothing
                  Just m -> Just def{_wsCells = fromRows . numberList . Prelude.map numberList $ m }
@@ -50,14 +49,19 @@ plugs2Sheets fSpec = M.fromList . catMaybes . Prelude.map plug2sheet $ plugInfos
                          [ if isFirstField  -- In case of the first field of the table, we put the fieldname inbetween brackets,
                                             -- to be able to find the population again by the reader of the .xlsx file
                            then Just $ "["++name fld++"]" 
-                           else Just $ name fld
+                           else Just . cleanUpRelName $ name fld
                          , Just $ name .target . fldexpr $ fld ]
-                              
+                   cleanUpRelName :: String -> String
+                   --TODO: This is a not-so-nice way to get the relationname from the fieldname.
+                   cleanUpRelName orig
+                     | isPrefixOf "tgt_" orig = drop 4 orig
+                     | isPrefixOf "src_" orig = drop 4 orig
+                     | otherwise         = orig
            content = fmap record2Cells (tblcontents (vgens fSpec) (initialPops fSpec) plug)
            record2Cells = fmap toCell
        toCell :: Maybe String -> Cell
        toCell mStr = Cell { _cellStyle = Nothing
-                         , _cellValue = fmap (\x -> CellText . pack $ x) mStr
+                         , _cellValue = fmap (\x -> CellText . T.pack $ x) mStr
                          }
        
 

--- a/src/Database/Design/Ampersand/Output/Population2Xlsx.hs
+++ b/src/Database/Design/Ampersand/Output/Population2Xlsx.hs
@@ -2,24 +2,68 @@
 module Database.Design.Ampersand.Output.Population2Xlsx
   (fSpec2PopulationXlsx)
 where
-import Database.Design.Ampersand.Misc
 import Database.Design.Ampersand.FSpec
-import Database.Design.Ampersand.Core.AbstractSyntaxTree
-import Database.Design.Ampersand.FSpec.FPA
 import Database.Design.Ampersand.Basics
+import Database.Design.Ampersand.Core.AbstractSyntaxTree
 import System.Time
-
+import qualified Data.Map as M
 import Codec.Xlsx
-import Control.Lens
 import qualified Data.ByteString.Lazy as L
-import System.Time
+import Data.Text hiding (zip, transpose)
+import Data.Maybe
+import Data.List
 
 fSpec2PopulationXlsx :: ClockTime -> FSpec -> L.ByteString 
 fSpec2PopulationXlsx ct fSpec = 
   fromXlsx ct xlsx
     where
-      sheet = def & cellValueAt (1,2) ?~ CellDouble 42.0
-                  & cellValueAt (3,2) ?~ CellText "foo"
-      xlsx = def & atSheet "List1" ?~ sheet
+      xlsx =def { _xlSheets = plugs2Sheets fSpec}
+               
      
 
+plugs2Sheets :: FSpec -> M.Map Text Worksheet
+plugs2Sheets fSpec = M.fromList . catMaybes . Prelude.map plug2sheet $ plugInfos fSpec
+  where
+    plug2sheet :: PlugInfo -> Maybe (Text, Worksheet)
+    plug2sheet ExternalPlug{} = Nothing  -- Not supported at present
+    plug2sheet (InternalPlug plug) = fmap (\x -> (pack (name plug),x)) sheet
+      where 
+       sheet :: Maybe Worksheet
+       --sheet = def & cellValueAt (1,1) ?~ CellText (pack ("["++name plug++"'s]"))
+       sheet = case matrix of
+                 Nothing -> Nothing
+                 Just m -> Just def{_wsCells = fromRows . numberList . Prelude.map numberList $ m }
+            where 
+              numberList :: [c] -> [(Int, c)]
+              numberList = zip [1..] 
+       matrix :: Maybe  [[Cell]]
+       matrix = 
+         case plug of
+           TblSQL{} -> Just $ headers ++ content  
+           BinSQL{} -> Nothing
+           ScalarSQL{} -> Nothing
+--       field2Row :: SqlField -> [Cell]
+--       field2Row fld = headerRows ++ content
+         where
+           headers :: [[Cell]]
+           headers = transpose (Prelude.map f (fields plug)) 
+             where f :: SqlField -> [Cell]
+                   f fld = Prelude.map toCell 
+                             [ case flduse fld of -- In case of the main concept of the table, we put the fieldname inbetween brackets,
+                                                  -- to be able to find the population again by the reader of the .xlsx file
+                                 (TableKey True _) -> Just $ "["++name fld++"]" 
+                                 _ ->  Just $ name fld
+                             , Just $ name .target . fldexpr $ fld ]
+           content = Prelude.map record2Cells (tblcontents (vgens fSpec) (initialPops fSpec) plug)
+           record2Cells :: TblRecord -> [Cell]
+           record2Cells = fmap toCell
+       toCell :: Maybe String -> Cell
+       toCell mStr = Cell { _cellStyle = Nothing
+                         , _cellValue = fmap (\x -> CellText . pack $ x) mStr
+                         }
+       
+       -- case tblcontents (vgens fSpec) (initialPops fSpec) plug of
+type TblRecord = [Maybe String]
+
+  
+            

--- a/src/Database/Design/Ampersand/Output/Population2Xlsx.hs
+++ b/src/Database/Design/Ampersand/Output/Population2Xlsx.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Database.Design.Ampersand.Output.Population2Xlsx
+  (fSpec2PopulationXlsx)
+where
+import Database.Design.Ampersand.Misc
+import Database.Design.Ampersand.FSpec
+import Database.Design.Ampersand.Core.AbstractSyntaxTree
+import Database.Design.Ampersand.FSpec.FPA
+import Database.Design.Ampersand.Basics
+import System.Time
+
+import Codec.Xlsx
+import Control.Lens
+import qualified Data.ByteString.Lazy as L
+import System.Time
+
+fSpec2PopulationXlsx :: ClockTime -> FSpec -> L.ByteString 
+fSpec2PopulationXlsx ct fSpec = 
+  fromXlsx ct xlsx
+    where
+      sheet = def & cellValueAt (1,2) ?~ CellDouble 42.0
+                  & cellValueAt (3,2) ?~ CellText "foo"
+      xlsx = def & atSheet "List1" ?~ sheet
+     
+


### PR DESCRIPTION
Now we have a reader and a writer for populations to and from .xlsx files. 
Use the switch --pop-xlsx to get yourself an .xlsx file with all your populations
To read populations from such an .xlsx file, just INCLUDE it. (the extension triggers the .xlsx parser) 