### PR TITLE
Add compression on static files.

### DIFF
--- a/ampersand.cabal
+++ b/ampersand.cabal
@@ -53,6 +53,7 @@ executable ampersand
                      utf8-string == 0.3.*,
                      text >=1.1 && <1.3,
                      xlsx == 0.1.*,
+                     zlib,
                      lens,
                      MissingH,
                      wl-pprint
@@ -185,6 +186,7 @@ Test-Suite ampersand-test
                      transformers >=0.3 && <0.4,
                      conduit >=1.2 && <1.3,
                      xlsx == 0.1.*,
+                     zlib,
                      lens
   other-modules:     
                      Database.Design.Ampersand.Misc.Options,


### PR DESCRIPTION
Generated static file may be a bit larger, but 4 MB (50% of the static file-size) of the final Ampersand executable is saved.
I only realised later that the 230 MB of Ampersand is not due to the static files, so it won't change much overall (saves 4 out of 234 MB, about 2%)