### PR TITLE
Upgrade to stack LTS-5.1. This updates pandoc and downgrades aeson. L…

### DIFF
--- a/ampersand.cabal
+++ b/ampersand.cabal
@@ -1,5 +1,5 @@
 name:           ampersand
-version:        3.3.0
+version:        3.4.0
 author:         Stef Joosten
 maintainer:     stef.joosten@ou.nl
 synopsis:       Toolsuite for automated design of business processes.
@@ -29,7 +29,7 @@ executable ampersand
   hs-source-dirs:    src
   default-language:  Haskell2010
   ghc-options:       -rtsopts -Wall
-  build-depends:     aeson == 0.10.*,
+  build-depends:     aeson == 0.9.*,
                      aeson-pretty == 0.7.*,
                      base >= 4.7 && < 5.0,
                      bytestring == 0.10.*,
@@ -43,8 +43,8 @@ executable ampersand
                      HStringTemplate == 0.8.*,
                      lens == 4.13.*,
                      mtl == 2.2.*,
-                     pandoc >= 1.15.0.6 && == 1.15.*,
-                     pandoc-types == 1.12.*,
+                     pandoc == 1.16.*,
+                     pandoc-types == 1.16.*,
                      parsec == 3.1.*,
                      process == 1.2.*,
                      simple-sql-parser == 0.4.1,
@@ -184,8 +184,8 @@ Test-Suite ampersand-test
                      lens == 4.13.*,
                      MissingH == 1.3.*,
                      mtl == 2.2.*,
-                     pandoc >= 1.15.0.6 && == 1.15.*,
-                     pandoc-types == 1.12.*,
+                     pandoc == 1.16.*,
+                     pandoc-types == 1.16.*,
                      parsec == 3.1.*,
                      QuickCheck == 2.8.*,
                      simple-sql-parser == 0.4.1,

--- a/outputTemplates/default.latex
+++ b/outputTemplates/default.latex
@@ -10,7 +10,6 @@ $if(linestretch)$
 $endif$
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
-\usepackage{fixltx2e} % provides \textsubscript
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
   \usepackage[utf8]{inputenc}

--- a/src/Database/Design/Ampersand/Output/PandocAux.hs
+++ b/src/Database/Design/Ampersand/Output/PandocAux.hs
@@ -57,7 +57,7 @@ defaultWriterVariables fSpec
     , ("lang"    , case fsLang fSpec of
                        Dutch   -> "dutch"
                        English -> "english")
-    , ("papersize", "a4")
+    , ("papersize", "a4paper")
     , ("babel-lang", case fsLang fSpec of
                        Dutch   -> "dutch"
                        English -> "english")

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
 # resolver: lts-3.18
 # resolver: nightly-2015-09-21
-resolver: lts-4.2
+resolver: lts-5.1
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
…TS 4.* is discontinued (See https://www.reddit.com/r/haskell/comments/41gpdk/lts4_with_aeson010_is_being_discontinued_lts5/ )