### PR TITLE
Feature/copy customizations

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,8 @@
 
 ## unreleased changes
   * Added some additional diagnosis info in settings.json
+  * Added 'customization' folder to prototype generation process. This folder can be used to e.g. overwrite generated views.
+  * Includes for frontend app must be placed in 'app' folder now. The include folder thereby directly matches the destination directory structure.
 
 ## v3.7.3 (25 november 2016)
   * Alternative definition of univalence and injectivity to get better violations on runtime.

--- a/src/Ampersand/Prototype/GenFrontend.hs
+++ b/src/Ampersand/Prototype/GenFrontend.hs
@@ -95,13 +95,13 @@ clearTemplateDirs fSpec = mapM_ emptyDir ["views", "controllers"]
 
 doGenFrontend :: FSpec -> IO ()
 doGenFrontend fSpec =
- do { putStr "Generating frontend.." 
+ do { putStr "Generating frontend..\n" 
     ; copyIncludes fSpec
     ; feInterfaces <- buildInterfaces fSpec
     ; genViewInterfaces fSpec feInterfaces
     ; genControllerInterfaces fSpec feInterfaces
     ; genRouteProvider fSpec feInterfaces
-    ; putStrLn "frontend generated."
+    ; putStrLn "Frontend generated.\n"
     }
 
 copyIncludes :: FSpec -> IO ()
@@ -136,14 +136,9 @@ copyIncludes fSpec =
     } 
   where copyInclude :: Include -> IO()
         copyInclude incl =
-          do { verboseLn (getOpts fSpec) $ 
-                          "  Copying " ++ (case fileOrDir incl of 
-                                             File -> "file"
-                                             Dir  -> "directory"
-                                          )++ " " ++ includeSrc incl ++ "\n    -> " ++ includeTgt incl
-             ; case fileOrDir incl of
-                 File -> copyDeepFile (includeSrc incl) (includeTgt incl)
-                 Dir  -> copyDirRecursively (includeSrc incl) (includeTgt incl)
+          do { case fileOrDir incl of
+                 File -> copyDeepFile (includeSrc incl) (includeTgt incl) (getOpts fSpec)
+                 Dir  -> copyDirRecursively (includeSrc incl) (includeTgt incl) (getOpts fSpec)
              }
 ------ Build intermediate data structure
 

--- a/src/Ampersand/Prototype/GenFrontend.hs
+++ b/src/Ampersand/Prototype/GenFrontend.hs
@@ -62,12 +62,7 @@ data FileOrDir = File | Dir deriving Show
 -- Files/directories that will be copied to the prototype, if present in $adlSourceDir/includes/
 allowedIncludeSubDirs :: [Include]
 allowedIncludeSubDirs = [ Include Dir  "templates"         "templates"
-                        , Include Dir  "views"             "app/views"
-                        , Include Dir  "controllers"       "app/controllers"
-                        , Include Dir  "css"               "app/css"
-                        , Include Dir  "js"                "app/js"
-                        , Include Dir  "lib"               "app/lib"
-                        , Include Dir  "images"            "app/images"
+                        , Include Dir  "app"               "app"
                         , Include Dir  "extensions"        "extensions"
                         , Include File "localSettings.php" "localSettings.php"
                         ]

--- a/src/Ampersand/Prototype/GenFrontend.hs
+++ b/src/Ampersand/Prototype/GenFrontend.hs
@@ -101,6 +101,7 @@ doGenFrontend fSpec =
     ; genViewInterfaces fSpec feInterfaces
     ; genControllerInterfaces fSpec feInterfaces
     ; genRouteProvider fSpec feInterfaces
+    ; copyCustomizations fSpec
     ; putStrLn "Frontend generated.\n"
     }
 
@@ -140,6 +141,20 @@ copyIncludes fSpec =
                  File -> copyDeepFile (includeSrc incl) (includeTgt incl) (getOpts fSpec)
                  Dir  -> copyDirRecursively (includeSrc incl) (includeTgt incl) (getOpts fSpec)
              }
+
+copyCustomizations :: FSpec -> IO ()
+copyCustomizations fSpec =
+ do { let adlSourceDir = takeDirectory $ fileName (getOpts fSpec)
+          custDir = adlSourceDir </> "customizations"
+          protoDir = Opts.dirPrototype (getOpts fSpec)
+    ; custDirExists <- doesDirectoryExist custDir
+    ; if custDirExists then
+        do { verboseLn (getOpts fSpec) $ "Copying customizations from " ++ custDir ++ " -> " ++ protoDir
+           ; copyDirRecursively custDir protoDir (getOpts fSpec) -- recursively copy all includes
+           }
+      else
+        verboseLn (getOpts fSpec) $ "No customizations (there is no directory " ++ custDir ++ ")"
+    }
 ------ Build intermediate data structure
 
 -- NOTE: _ disables 'not used' warning for fields

--- a/src/Ampersand/Prototype/GenFrontend.hs
+++ b/src/Ampersand/Prototype/GenFrontend.hs
@@ -128,7 +128,7 @@ copyIncludes fSpec =
                       
           ; let ignoredPaths = includeDirContents \\ map includeSrc absIncludes
           ; when (any (\ str -> head str /= '.') ignoredPaths) $  --filter paths starting with a dot, because on mac this is very common and it is a nuisance to avoid (see issue #
-             do { putStrLn $ "\nWARNING: only the following include/ paths are allowed:\n  " ++ show (map includeSrc allowedIncludeSubDirs) ++ "\n"
+             do { putStrLn $ "\nWARNING: only the following include paths are allowed:\n  " ++ show (map includeSrc allowedIncludeSubDirs) ++ "\n"
                 ; mapM_ (\d -> putStrLn $ "  Ignored " ++ d) ignoredPaths
                 }
           }
@@ -155,8 +155,8 @@ copyCustomizations fSpec =
       else
         verboseLn (getOpts fSpec) $ "No customizations (there is no directory " ++ custDir ++ ")"
     }
------- Build intermediate data structure
 
+------ Build intermediate data structure
 -- NOTE: _ disables 'not used' warning for fields
 data FEInterface = FEInterface { ifcName :: String
                                , ifcLabel :: String

--- a/src/Ampersand/Prototype/ProtoUtil.hs
+++ b/src/Ampersand/Prototype/ProtoUtil.hs
@@ -41,25 +41,29 @@ getAppDir opts =
   
 -- Copy entire directory tree from srcBase/ to tgtBase/, overwriting existing files, but not emptying existing directories.
 -- NOTE: tgtBase specifies the copied directory target, not its parent
-copyDirRecursively :: FilePath -> FilePath -> IO ()
-copyDirRecursively srcBase tgtBase = copy ""
+copyDirRecursively :: FilePath -> FilePath -> Options -> IO ()
+copyDirRecursively srcBase tgtBase opts = copy ""
   where copy fileOrDirPth = 
          do { let srcPath = srcBase </> fileOrDirPth
                   tgtPath = tgtBase </> fileOrDirPth
             ; isDir <- doesDirectoryExist srcPath
             ; if isDir then 
                do { createDirectoryIfMissing True tgtPath
+                  ; verboseLn opts $ " Copying dir... " ++ srcPath
                   ; fOrDs <- getProperDirectoryContents srcPath
                   ; mapM_ (\fOrD -> copy $ fileOrDirPth </> fOrD) fOrDs
                   }
               else
-                copyFile srcPath tgtPath -- directory will exist, so no need for copyDeepFile
+               do { verboseLn opts $ "  file... " ++ fileOrDirPth
+                  ; copyFile srcPath tgtPath -- directory will exist, so no need for copyDeepFile
+                  }
             }
             
 -- Copy file while creating all subdirectories on the target path (if non-existent)
-copyDeepFile :: FilePath -> FilePath -> IO ()
-copyDeepFile srcPath tgtPath =
- do { createDirectoryIfMissing True (takeDirectory tgtPath)
+copyDeepFile :: FilePath -> FilePath -> Options -> IO ()
+copyDeepFile srcPath tgtPath opts =
+ do { verboseLn opts $ " Copying file... " ++ srcPath ++ " -> " ++ tgtPath
+    ; createDirectoryIfMissing True (takeDirectory tgtPath)
     ; copyFile srcPath tgtPath
     }
 


### PR DESCRIPTION
* Added 'customization' folder to prototype generation process. This folder can be used to e.g. overwrite generated views.
* Includes for frontend app must be placed in 'app' folder now. The include folder thereby directly matches the destination directory structure.

@hanjoosten would you review my code?