### PR TITLE
Feature/add formal ampersand relations

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,6 +6,7 @@
   * Added 'customization' folder to prototype generation process. This folder can be used to e.g. overwrite generated views.
   * Includes for frontend app must be placed in 'app' folder now. The include folder thereby directly matches the destination directory structure.
   * Ampersand version info is printed in verbose mode
+  * New switch, to add formal ampersand relations into your script: --add-meta-relations
 
 ## v3.7.3 (25 november 2016)
   * Alternative definition of univalence and injectivity to get better violations on runtime.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,7 +6,7 @@
   * Added 'customization' folder to prototype generation process. This folder can be used to e.g. overwrite generated views.
   * Includes for frontend app must be placed in 'app' folder now. The include folder thereby directly matches the destination directory structure.
   * Ampersand version info is printed in verbose mode
-  * New switch, to add formal ampersand relations into your script: --add-meta-relations
+  * New switch, to add all relations, concepts and generalisation relations of formal ampersand into your script: --add-semantic-metamodel
 
 ## v3.7.3 (25 november 2016)
   * Alternative definition of univalence and injectivity to get better violations on runtime.

--- a/src/Ampersand/FSpec/ToFSpec/CreateFspec.hs
+++ b/src/Ampersand/FSpec/ToFSpec/CreateFspec.hs
@@ -30,12 +30,24 @@ import Control.Monad
 createMulti :: Options  -- ^The options derived from the command line
             -> IO(Guarded MultiFSpecs)
 createMulti opts =
-  do userP_Ctx <- parseADL opts (fileName opts)     -- the P_Context of the user's sourceFile
+  do fAmpP_Ctx <-
+        if or [ genMetaFile          opts
+              , genMetaTables        opts
+              , genRapPopulationOnly opts
+              , addMetaRelations     opts 
+              ] 
+        then parseMeta opts  -- the P_Context of the formalAmpersand metamodel
+        else return --Not very nice way to do this, but effective. Don't try to remove the return, otherwise the fatal could be evaluated... 
+               $ fatal 38 "With the given switches, the formal ampersand model is not supposed to play any part."
+     rawUserP_Ctx <- parseADL opts (fileName opts) -- the P_Context of the user's sourceFile
+     let userP_Ctx =
+           if addMetaRelations opts
+           then addSemanticModelOf fAmpP_Ctx rawUserP_Ctx     
+           else rawUserP_Ctx
      let gFSpec = pCtx2Fspec userP_Ctx              -- the FSpec resuting from the user's souceFile
      when (genMetaFile opts) (dumpMetaFile gFSpec)
      if genMetaTables opts || genRap
-     then do fAmpP_Ctx <- parseMeta opts             -- the P_Context of the formalAmpersand metamodel
-             let gGrinded :: Guarded P_Context
+     then do let gGrinded :: Guarded P_Context
                  gGrinded = addGens <$> fAmpP_Ctx <*> join (grind <$> gFSpec) -- the user's sourcefile grinded, i.e. a P_Context containing population in terms of formalAmpersand.
              let metaPopFSpec = pCtx2Fspec gGrinded
              return $ mkMulti <$> (Just <$> metaPopFSpec) <*> combineAll [userP_Ctx, gGrinded, fAmpP_Ctx]
@@ -78,3 +90,12 @@ createMulti opts =
       where
        f (a,[]) = a
        f _      = fatal 83 "Meatgrinder returns included file. That isn't anticipated."
+
+
+addSemanticModelOf :: Guarded P_Context -> Guarded P_Context -> Guarded P_Context
+addSemanticModelOf = liftM2 f
+  where 
+    f :: P_Context -> P_Context -> P_Context
+    f fa usr = usr{ctx_ds = ctx_ds usr ++ ctx_ds fa ++ concatMap pt_dcs (ctx_pats fa)
+                  ,ctx_gs = ctx_gs usr ++ ctx_gs fa ++ concatMap pt_gns (ctx_pats fa)
+                  }

--- a/src/Ampersand/FSpec/ToFSpec/CreateFspec.hs
+++ b/src/Ampersand/FSpec/ToFSpec/CreateFspec.hs
@@ -31,17 +31,16 @@ createMulti :: Options  -- ^The options derived from the command line
             -> IO(Guarded MultiFSpecs)
 createMulti opts =
   do fAmpP_Ctx <-
-        if or [ genMetaFile          opts
-              , genMetaTables        opts
+        if or [ genMetaTables        opts
               , genRapPopulationOnly opts
-              , addMetaRelations     opts 
+              , addSemanticMetaModel opts 
               ] 
         then parseMeta opts  -- the P_Context of the formalAmpersand metamodel
         else return --Not very nice way to do this, but effective. Don't try to remove the return, otherwise the fatal could be evaluated... 
                $ fatal 38 "With the given switches, the formal ampersand model is not supposed to play any part."
      rawUserP_Ctx <- parseADL opts (fileName opts) -- the P_Context of the user's sourceFile
      let userP_Ctx =
-           if addMetaRelations opts
+           if addSemanticMetaModel opts
            then addSemanticModelOf fAmpP_Ctx rawUserP_Ctx     
            else rawUserP_Ctx
      let gFSpec = pCtx2Fspec userP_Ctx              -- the FSpec resuting from the user's souceFile

--- a/src/Ampersand/Misc/Options.hs
+++ b/src/Ampersand/Misc/Options.hs
@@ -76,6 +76,7 @@ data Options = Options { environment :: EnvironmentOptions
                        , test :: Bool
                        , genMetaTables :: Bool -- When set, generate the meta-tables of AST into the prototype
                        , genMetaFile :: Bool  -- When set, output the meta-population as a file
+                       , addMetaRelations :: Bool -- When set, the user can use all relations defined in Formal Ampersand, without the need to specify them explicitly
                        , genRapPopulationOnly :: Bool -- This switch is to tell Ampersand that the model is being used in RAP3 as student's model
                        , sqlHost ::  String  -- do database queries to the specified host
                        , sqlLogin :: String  -- pass login name to the database server
@@ -242,6 +243,7 @@ getOptions' envOpts =
                       , test             = False
                       , genMetaTables    = False
                       , genMetaFile      = False
+                      , addMetaRelations = False
                       , genRapPopulationOnly = False
                       , sqlHost          = "localhost"
                       , sqlLogin         = "ampersand"
@@ -542,6 +544,10 @@ options = [ (Option ['v']   ["version"]
           , (Option []        ["meta-file"]
                (NoArg (\opts -> opts{genMetaFile = True}))
                "Generate the meta-population in AST format and output it to an .adl file"
+            , Hidden)
+          , (Option []        ["add-meta-relations"]
+               (NoArg (\opts -> opts{addMetaRelations = True}))
+               "add the relations of Formal Ampersand into your script"
             , Hidden)
           , (Option []        ["gen-as-rap-model"]
                (NoArg (\opts -> opts{genRapPopulationOnly = True}))

--- a/src/Ampersand/Misc/Options.hs
+++ b/src/Ampersand/Misc/Options.hs
@@ -76,7 +76,7 @@ data Options = Options { environment :: EnvironmentOptions
                        , test :: Bool
                        , genMetaTables :: Bool -- When set, generate the meta-tables of AST into the prototype
                        , genMetaFile :: Bool  -- When set, output the meta-population as a file
-                       , addMetaRelations :: Bool -- When set, the user can use all relations defined in Formal Ampersand, without the need to specify them explicitly
+                       , addSemanticMetaModel :: Bool -- When set, the user can use all relations defined in Formal Ampersand, without the need to specify them explicitly
                        , genRapPopulationOnly :: Bool -- This switch is to tell Ampersand that the model is being used in RAP3 as student's model
                        , sqlHost ::  String  -- do database queries to the specified host
                        , sqlLogin :: String  -- pass login name to the database server
@@ -243,7 +243,7 @@ getOptions' envOpts =
                       , test             = False
                       , genMetaTables    = False
                       , genMetaFile      = False
-                      , addMetaRelations = False
+                      , addSemanticMetaModel = False
                       , genRapPopulationOnly = False
                       , sqlHost          = "localhost"
                       , sqlLogin         = "ampersand"
@@ -545,9 +545,9 @@ options = [ (Option ['v']   ["version"]
                (NoArg (\opts -> opts{genMetaFile = True}))
                "Generate the meta-population in AST format and output it to an .adl file"
             , Hidden)
-          , (Option []        ["add-meta-relations"]
-               (NoArg (\opts -> opts{addMetaRelations = True}))
-               "add the relations of Formal Ampersand into your script"
+          , (Option []        ["add-semantic-metamodel"]
+               (NoArg (\opts -> opts{addSemanticMetaModel = True}))
+               "Add all relations, concepts and generalisation relations of formal ampersand into your script"
             , Hidden)
           , (Option []        ["gen-as-rap-model"]
                (NoArg (\opts -> opts{genRapPopulationOnly = True}))


### PR DESCRIPTION
New switch, to add all relations, concepts and generalisation relations of formal ampersand into your script: --add-semantic-metamodel

This is a powerfull switch when you want to make models where you use FormalAmpersand