### PR TITLE
Default language and matching brackets of markup

### DIFF
--- a/AmpersandData/FormalAmpersand/Contexts.adl
+++ b/AmpersandData/FormalAmpersand/Contexts.adl
@@ -11,11 +11,11 @@ VIEW Signature: Signature( TXT "[" , src;name[Concept*ConceptName] , TXT "*" , t
 --PATTERN Authorizations
 --PURPOSE PATTERN Authorizations
 --{+
----}
+--+}
 --PURPOSE RELATION owner[Context*Account]
 --{+In RAP, every context must have one owner, who can exercise all ownership rights that contexts have.
 --Initially, the creator of a context is its owner.
----}
+--+}
 --    RELATION owner[Context*Account] [UNI]
 --    MEANING "A context has an owner, which is an account."
 --    ROLE ExecEngine MAINTAINS TOTowner
@@ -64,7 +64,7 @@ PATTERN Context
 
     PURPOSE RULE "rule declared outside pattern"
     {+Ampersand allows its users to declare rules in a context, outside the scope of a pattern.
-    -}
+    +}
     ROLE ExecEngine MAINTAINS "rule declared outside pattern"
     RULE "rule declared outside pattern" : ctxrs[Rule*Context] |- udefrules[Rule*Context]
     MEANING "A rule declared in a context outside the scope of a pattern is registered in the system."
@@ -72,7 +72,7 @@ PATTERN Context
 
     PURPOSE RULE "all rules"
     {+It is convenient to have one relation to contain all rules in a context. TODO: delete rules from allRules.
-    -}
+    +}
     ROLE ExecEngine MAINTAINS "all rules"
     RULE "all rules" : udefrules[Rule*Context] \/ multrules \/ identityRules |- allRules[Context*Rule]~
     MEANING "All rules in a context consist of the user-defined rules, the multiplicity rules, and the identity rules."
@@ -80,7 +80,7 @@ PATTERN Context
 
     PURPOSE RULE "relation declared outside pattern"
     {+Ampersand allows its users to declare relations in a context, outside the scope of a pattern.
-    -}
+    +}
     ROLE ExecEngine MAINTAINS "relation declared outside pattern"
     RULE "relation declared outside pattern" : ctxds[Relation*Context] |- declaredIn[Relation*Context]
     MEANING "A relation declared in a context outside the scope of a pattern is registered in the system."
@@ -88,7 +88,7 @@ PATTERN Context
 
     PURPOSE RULE "pat defined in means used in"
     {+Patterns can be defined inside a context. This means that all declarations in that pattern are used in that context.
-    -}
+    +}
     ROLE ExecEngine MAINTAINS "pat defined in means used in"
     RULE "pat defined in means used in" : context[Pattern*Context] |- uses[Context*Pattern]~
     MEANING "Every pattern defined in a context is used in that context."
@@ -99,7 +99,7 @@ PURPOSE PATTERN Validity
 {+The mechanism to define truth within context is represented by the relation `valid`.
 The idea is that a context determines concepts, relations and rules, all of which we say are `valid` in the context.
 For this purpose we define three relations, `valid[Concept*Context]`, `valid[Relation*Context]`, and `valid[Rule*Context]`.
--}
++}
 PATTERN Validity
     RELATION valid[Concept*Context]
     MEANING "A concept/context pair in the relation `valid[Concept*Context]` means that this concept exists with the context."
@@ -109,7 +109,7 @@ PATTERN Validity
      - the concept defined in the context
      - all concept defined in patterns within the context
      - all concept defined in patterns used by the context
-    -}
+    +}
     ROLE ExecEngine MAINTAINS validConcepts
     RULE validConcepts : concepts~;(context\/uses~) \/ context |- valid[Concept*Context]
     MEANING "Every concept defined in one of the patterns inside a context, or in the context itself, or in one of the contexts used by this context, is valid throughout that context."
@@ -131,7 +131,7 @@ PATTERN Validity
      - the relation defined in the context
      - all relation defined in patterns within the context
      - all relation defined in patterns used by the context
-    -}
+    +}
     ROLE ExecEngine MAINTAINS validRelations
     RULE validRelations : declaredIn[Relation*Pattern];(context\/uses~) \/ ctxds |- valid[Relation*Context]
     MEANING "Every relation defined in one of the patterns inside a context, or in the context itself, or in one of the contexts used by this context, is valid throughout that context."
@@ -150,7 +150,7 @@ PATTERN Validity
      - the rules defined in the context
      - all rules defined in patterns within the context
      - all rules defined in patterns used by the context
-    -}
+    +}
     ROLE ExecEngine MAINTAINS validRules
     RULE validRules : allRules[Pattern*Rule]~;(context\/uses~) \/ allRules[Context*Rule]~ |- valid[Rule*Context]
     MEANING "Every rule defined in one of the patterns inside a context, or in the context itself, or in one of the contexts used by this context, is valid throughout that context."
@@ -212,7 +212,7 @@ PATTERN Specialization
 --PURPOSE RULE specialization
 --{+Specialization has the consequence that an atom is not necessarily an instance of one concept only.
 --If limes are citrus fruits, then every lime is not only lime but a citrus fruit as well.
----}
+--+}
 --RELATION instanceOf[Atom*Concept] [TOT] 
 --RULE specialization : instanceOf;genspc~;gengen |- instanceOf
 --MEANING "Every instance of a specialized concept is an instance of the generic concept too."

--- a/AmpersandData/FormalAmpersand/Documentation.adl
+++ b/AmpersandData/FormalAmpersand/Documentation.adl
@@ -1,7 +1,7 @@
 CONTEXT RAP IN ENGLISH
 PURPOSE PATTERN Documentation
 {+
--}
++}
 PATTERN Documentation
     RELATION purpose[Pattern*Purpose] [INJ]
     MEANING "The purposes of a pattern."

--- a/AmpersandData/FormalAmpersand/Expressions.docadl
+++ b/AmpersandData/FormalAmpersand/Expressions.docadl
@@ -4,7 +4,7 @@ INCLUDE "Terms.adl"
 
 CONCEPT Signature "A signature is a pair of concepts."
 PURPOSE CONCEPT Signature
-{+Every relation gets a signature when declared, for the purpose of classifying atoms in that relation.-}
+{+Every relation gets a signature when declared, for the purpose of classifying atoms in that relation.+}
 
 PURPOSE RELATION src[Signature*Concept]
 {+The src-concept of a signature corresponds to the source concept of a relation, which serves the purpose of classifying all atoms as instances of that concept.
@@ -23,13 +23,13 @@ PURPOSE RULE totSign
 -}
 
 PURPOSE RULE signatureSrcIns
-{+The relation src[Signature*Concept] must be filled automatically as soon as a new signature is made.-}
+{+The relation src[Signature*Concept] must be filled automatically as soon as a new signature is made.+}
 PURPOSE RULE signatureTgtIns
-{+The relation tgt[Signature*Concept] must be filled automatically as soon as a new signature is made.-}
+{+The relation tgt[Signature*Concept] must be filled automatically as soon as a new signature is made.+}
 PURPOSE RULE signatureSrcDel
-{+The relation src[Signature*Concept] must be cleared automatically as soon as a signature is deleted.-}
+{+The relation src[Signature*Concept] must be cleared automatically as soon as a signature is deleted.+}
 PURPOSE RULE signatureTgtDel
-{+The relation tgt[Signature*Concept] must be cleared automatically as soon as a signature is deleted.-}
+{+The relation tgt[Signature*Concept] must be cleared automatically as soon as a signature is deleted.+}
 
 CONCEPT TypeTerm "A type-term represents a set of atoms."
 PURPOSE CONCEPT TypeTerm

--- a/AmpersandData/FormalAmpersand/Generics.adl
+++ b/AmpersandData/FormalAmpersand/Generics.adl
@@ -1,6 +1,6 @@
 ﻿CONTEXT Generics IN ENGLISH LATEX
 PURPOSE CONTEXT Generics
-{+This context specifies the administration that currrently is, and in future will have been, the contents of GENERICS.PHP-}
+{+This context specifies the administration that currrently is, and in future will have been, the contents of GENERICS.PHP+}
 
 REPRESENT MySQLQuery TYPE BIGALPHANUMERIC
 

--- a/AmpersandData/FormalAmpersand/TypeChecking.docadl
+++ b/AmpersandData/FormalAmpersand/TypeChecking.docadl
@@ -4,7 +4,7 @@ INCLUDE "Terms.adl"
 
 CONCEPT Signature "A signature is a pair of concepts."
 PURPOSE CONCEPT Signature
-{+Every relation gets a signature when declared, for the purpose of classifying atoms in that relation.-}
+{+Every relation gets a signature when declared, for the purpose of classifying atoms in that relation.+}
 
 PURPOSE RELATION src[Signature*Concept]
 {+The src-concept of a signature corresponds to the source concept of a relation, which serves the purpose of classifying all atoms as instances of that concept.
@@ -23,13 +23,13 @@ PURPOSE RULE totSign
 -}
 
 PURPOSE RULE signatureSrcIns
-{+The relation src[Signature*Concept] must be filled automatically as soon as a new signature is made.-}
+{+The relation src[Signature*Concept] must be filled automatically as soon as a new signature is made.+}
 PURPOSE RULE signatureTgtIns
-{+The relation tgt[Signature*Concept] must be filled automatically as soon as a new signature is made.-}
+{+The relation tgt[Signature*Concept] must be filled automatically as soon as a new signature is made.+}
 PURPOSE RULE signatureSrcDel
-{+The relation src[Signature*Concept] must be cleared automatically as soon as a signature is deleted.-}
+{+The relation src[Signature*Concept] must be cleared automatically as soon as a signature is deleted.+}
 PURPOSE RULE signatureTgtDel
-{+The relation tgt[Signature*Concept] must be cleared automatically as soon as a signature is deleted.-}
+{+The relation tgt[Signature*Concept] must be cleared automatically as soon as a signature is deleted.+}
 
 CONCEPT TypeTerm "A type-term represents a set of atoms."
 PURPOSE CONCEPT TypeTerm

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## unreleased changes
   * [Issue #587](https://github.com/AmpersandTarski/Ampersand/issues/587) There is no need any longer to explicitly specify the language in a script. If omitted, IN ENGLISH will be used as default. 
+  * [Issue #588](https://github.com/AmpersandTarski/Ampersand/issues/588) PURPOSE sytax changed: Now matching brackets: `{+` and `+}`
   * Added some additional diagnosis info in settings.json
   * Added support for project/application and extension specific composer dependencies.
   * Added 'customization' folder to prototype generation process. This folder can be used to e.g. overwrite generated views.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,7 +2,7 @@
 
 ## unreleased changes
   * [Issue #587](https://github.com/AmpersandTarski/Ampersand/issues/587) There is no need any longer to explicitly specify the language in a script. If omitted, IN ENGLISH will be used as default. 
-  * [Issue #588](https://github.com/AmpersandTarski/Ampersand/issues/588) PURPOSE sytax changed: Now matching brackets: `{+` and `+}`
+  * [Issue #588](https://github.com/AmpersandTarski/Ampersand/issues/588) PURPOSE sytax changed: Now matching brackets are: `{+` and `+}` 
   * Added some additional diagnosis info in settings.json
   * Added support for project/application and extension specific composer dependencies.
   * Added 'customization' folder to prototype generation process. This folder can be used to e.g. overwrite generated views.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,7 @@
 # Release notes of Ampersand
 
 ## unreleased changes
+  * [Issue #587](https://github.com/AmpersandTarski/Ampersand/issues/587) There is no need any longer to explicitly specify the language in a script. If omitted, IN ENGLISH will be used as default. 
   * Added some additional diagnosis info in settings.json
   * Added support for project/application and extension specific composer dependencies.
   * Added 'customization' folder to prototype generation process. This folder can be used to e.g. overwrite generated views.

--- a/src/Ampersand/ADL1/P2A_Converters.hs
+++ b/src/Ampersand/ADL1/P2A_Converters.hs
@@ -285,7 +285,7 @@ pCtx2aCtx opts
   where
     concGroups = (\x -> trace (show x) x) $
                  getGroups genLatticeIncomplete :: [[Type]]
-    deflangCtxt = fromMaybe English $ ctxmLang `orElse` (language opts)
+    deflangCtxt = fromMaybe English $ ctxmLang `orElse` language opts
     deffrmtCtxt = fromMaybe ReST pandocf
     
     allGens = p_gens ++ concatMap pt_gns p_patterns

--- a/src/Ampersand/ADL1/P2A_Converters.hs
+++ b/src/Ampersand/ADL1/P2A_Converters.hs
@@ -210,7 +210,7 @@ pCtx2aCtx :: Options -> P_Context -> Guarded A_Context
 pCtx2aCtx opts
  PCtx { ctx_nm     = n1
       , ctx_pos    = n2
-      , ctx_lang   = lang
+      , ctx_lang   = ctxmLang
       , ctx_markup = pandocf
       , ctx_thms   = p_themes 
       , ctx_pats   = p_patterns
@@ -285,7 +285,7 @@ pCtx2aCtx opts
   where
     concGroups = (\x -> trace (show x) x) $
                  getGroups genLatticeIncomplete :: [[Type]]
-    deflangCtxt = lang -- take the default language from the top-level context
+    deflangCtxt = fromMaybe English $ ctxmLang `orElse` (language opts)
     deffrmtCtxt = fromMaybe ReST pandocf
     
     allGens = p_gens ++ concatMap pt_gns p_patterns
@@ -1070,3 +1070,8 @@ getConcept Src = aConcToType . source
 getConcept Tgt = aConcToType . target
 
 
+-- | Left-biased choice on maybes
+orElse :: Maybe a -> Maybe a -> Maybe a
+x `orElse` y = case x of
+                 Just _  -> x
+                 Nothing -> y

--- a/src/Ampersand/ADL1/PrettyPrinters.hs
+++ b/src/Ampersand/ADL1/PrettyPrinters.hs
@@ -47,11 +47,11 @@ quote = text.show
 --              escape x = replace x ("\\" ++ x)
 
 quotePurpose :: String -> Doc
-quotePurpose p = text "{+" </> escapeExpl p </> text "-}"
+quotePurpose p = text "{+" </> escapeExpl p </> text "+}"
         where escapeExpl = text.escapeCommentStart.escapeLineComment.escapeExplEnd
               escapeCommentStart = escape "{-"
               escapeLineComment = escape "--"
-              escapeExplEnd = escape "-}"
+              escapeExplEnd = escape "+}"
               escape x = replace x (intersperse ' ' x)
 
 isId :: String -> Bool

--- a/src/Ampersand/Core/A2P_Converters.hs
+++ b/src/Ampersand/Core/A2P_Converters.hs
@@ -13,7 +13,7 @@ aCtx2pCtx :: A_Context -> P_Context
 aCtx2pCtx ctx = 
  PCtx { ctx_nm     = ctxnm ctx
       , ctx_pos    = ctxpos ctx
-      , ctx_lang   = ctxlang ctx
+      , ctx_lang   = Just $ ctxlang ctx
       , ctx_markup = Just $ ctxmarkup ctx
       , ctx_thms   = ctxthms ctx 
       , ctx_pats   = map aPattern2pPattern . ctxpats $ ctx

--- a/src/Ampersand/Core/ParseTree.hs
+++ b/src/Ampersand/Core/ParseTree.hs
@@ -56,7 +56,7 @@ import qualified Data.Set as Set
 data P_Context
    = PCtx{ ctx_nm ::     String           -- ^ The name of this context
          , ctx_pos ::    [Origin]         -- ^ The origins of the context. A context can be a merge of a file including other files c.q. a list of Origin.
-         , ctx_lang ::   Lang             -- ^ The default language specified on the top-level context
+         , ctx_lang ::   Maybe Lang       -- ^ The language specified on the top-level context. If omitted, English will be the default.
          , ctx_markup :: Maybe PandocFormat  -- ^ The default markup format for free text in this context
          , ctx_thms ::   [String]         -- ^ Names of patterns/processes to be printed in the functional specification. (For partial documents.)
          , ctx_pats ::   [P_Pattern]      -- ^ The patterns defined in this context

--- a/src/Ampersand/Input/ADL1/Lexer.hs
+++ b/src/Ampersand/Input/ADL1/Lexer.hs
@@ -235,8 +235,7 @@ lexNestComment _ p []          = lexerError UnterminatedComment p
 --TODO: Also accept {+ ... +} as delimiters
 lexMarkup :: Lexer -> Lexer
 lexMarkup = lexMarkup' ""
- where 
-    -- lexMarkup' str _ p ('-':'}':s) = returnToken (LexMarkup str) p mainLexer (addPos 2 p)  s -- for backwards compatibility with old `{+ ... -}` notation.
+ where lexMarkup' str _ p ('-':'}':s) = returnToken (LexMarkup str) p mainLexer (addPos 2 p)  s -- for backwards compatibility with old `{+ ... -}` notation.
        lexMarkup' str _ p ('+':'}':s) = returnToken (LexMarkup str) p mainLexer (addPos 2 p)  s
        lexMarkup' str c p (x:s)       = lexMarkup' (str++[x]) c (updatePos p x) s
        lexMarkup' _   _ p []          = lexerError UnterminatedMarkup p

--- a/src/Ampersand/Input/ADL1/Lexer.hs
+++ b/src/Ampersand/Input/ADL1/Lexer.hs
@@ -238,7 +238,7 @@ lexMarkup = lexMarkup' ""
  where lexMarkup' str _ p ('-':'}':s) = returnToken (LexMarkup str) p mainLexer (addPos 2 p)  s -- for backwards compatibility with old `{+ ... -}` notation.
        lexMarkup' str _ p ('+':'}':s) = returnToken (LexMarkup str) p mainLexer (addPos 2 p)  s
        lexMarkup' str c p (x:s)       = lexMarkup' (str++[x]) c (updatePos p x) s
-       lexMarkup' _   _ p []          = lexerError UnterminatedPurpose p
+       lexMarkup' _   _ p []          = lexerError UnterminatedMarkup p
 
 -----------------------------------------------------------
 -- iso 8601 date / time

--- a/src/Ampersand/Input/ADL1/Lexer.hs
+++ b/src/Ampersand/Input/ADL1/Lexer.hs
@@ -235,7 +235,8 @@ lexNestComment _ p []          = lexerError UnterminatedComment p
 --TODO: Also accept {+ ... +} as delimiters
 lexMarkup :: Lexer -> Lexer
 lexMarkup = lexMarkup' ""
- where lexMarkup' str _ p ('-':'}':s) = returnToken (LexMarkup str) p mainLexer (addPos 2 p)  s -- for backwards compatibility with old `{+ ... -}` notation.
+ where 
+    -- lexMarkup' str _ p ('-':'}':s) = returnToken (LexMarkup str) p mainLexer (addPos 2 p)  s -- for backwards compatibility with old `{+ ... -}` notation.
        lexMarkup' str _ p ('+':'}':s) = returnToken (LexMarkup str) p mainLexer (addPos 2 p)  s
        lexMarkup' str c p (x:s)       = lexMarkup' (str++[x]) c (updatePos p x) s
        lexMarkup' _   _ p []          = lexerError UnterminatedMarkup p

--- a/src/Ampersand/Input/ADL1/Lexer.hs
+++ b/src/Ampersand/Input/ADL1/Lexer.hs
@@ -101,9 +101,6 @@ lexer opt file input = case runLexerMonad opt file (mainLexer (initPos file) inp
 skipLine :: String -> String
 skipLine = dropWhile (/= '\n')
 
-takeLine :: String -> String
-takeLine = takeWhile (/= '\n')
-
 -----------------------------------------------------------
 -- Lexer definition
 -----------------------------------------------------------
@@ -123,12 +120,8 @@ mainLexer p ('-':'-':s) = mainLexer p (skipLine s) --TODO: Test if we should inc
 mainLexer p (c:s) | isSpace c = let (spc,next) = span isSpace s
                                 in  mainLexer (foldl updatePos p (c:spc)) next
 
-mainLexer p ('-':'+':s)  = returnToken lx p mainLexer p rest
-                where lx   = LexExpl $ dropWhile isSpace (takeLine s)
-                      rest = skipLine s
-
-mainLexer p ('{':'-':s) = lexNest mainLexer (addPos 2 p) s
-mainLexer p ('{':'+':s) = lexExpl mainLexer (addPos 2 p) s
+mainLexer p ('{':'-':s) = lexNestComment mainLexer (addPos 2 p) s
+mainLexer p ('{':'+':s) = lexMarkup mainLexer (addPos 2 p) s
 mainLexer p ('"':ss) =
     let (s,swidth,rest) = scanString ss
     in if null rest || head rest /= '"'
@@ -233,20 +226,19 @@ scanIdent p s = let (name,rest) = span isIdChar s
 -- String clean-up functions / comments
 -----------------------------------------------------------
 
-lexNest :: Lexer -> Lexer
-lexNest c p ('-':'}':s) = c (addPos 2 p) s
-lexNest c p ('{':'-':s) = lexNest (lexNest c) (addPos 2 p) s
-lexNest c p (x:s)       = lexNest c (updatePos p x) s
-lexNest _ p []          = lexerError UnterminatedComment p
+lexNestComment :: Lexer -> Lexer
+lexNestComment c p ('-':'}':s) = c (addPos 2 p) s
+lexNestComment c p ('{':'-':s) = lexNestComment (lexNestComment c) (addPos 2 p) s
+lexNestComment c p (x:s)       = lexNestComment c (updatePos p x) s
+lexNestComment _ p []          = lexerError UnterminatedComment p
 
 --TODO: Also accept {+ ... +} as delimiters
-lexExpl :: Lexer -> Lexer
-lexExpl = lexExpl' ""
- where lexExpl' str _ p ('-':'}':s) = returnToken (LexExpl str) p mainLexer (addPos 2 p)  s
-       lexExpl' str c p ('{':'-':s) = lexNest (lexExpl' str c) (addPos 2 p) s
-       lexExpl' str c p ('-':'-':s) = lexExpl' str c p (dropWhile (/= '\n') s)
-       lexExpl' str c p (x:s)       = lexExpl' (str++[x]) c (updatePos p x) s
-       lexExpl' _   _ p []          = lexerError UnterminatedPurpose p
+lexMarkup :: Lexer -> Lexer
+lexMarkup = lexMarkup' ""
+ where lexMarkup' str _ p ('-':'}':s) = returnToken (LexMarkup str) p mainLexer (addPos 2 p)  s -- for backwards compatibility with old `{+ ... -}` notation.
+       lexMarkup' str _ p ('+':'}':s) = returnToken (LexMarkup str) p mainLexer (addPos 2 p)  s
+       lexMarkup' str c p (x:s)       = lexMarkup' (str++[x]) c (updatePos p x) s
+       lexMarkup' _   _ p []          = lexerError UnterminatedPurpose p
 
 -----------------------------------------------------------
 -- iso 8601 date / time

--- a/src/Ampersand/Input/ADL1/LexerMessage.hs
+++ b/src/Ampersand/Input/ADL1/LexerMessage.hs
@@ -21,8 +21,8 @@ data LexerError = LexerError FilePos LexerErrorInfo -- ^ The lexer file position
 data LexerErrorInfo
     -- | The comment was not terminated
     = UnterminatedComment
-    -- | The purpose statement was not terminated
-    | UnterminatedPurpose
+    -- | The markup section was not terminated
+    | UnterminatedMarkup
     -- | The atom was not terminated
     | UnterminatedAtom
     -- | The character was unexpected
@@ -47,7 +47,7 @@ showLexerErrorInfo :: LexerErrorInfo -- ^ The error information
 showLexerErrorInfo info =
     case info of
         UnterminatedComment          -> [ Texts.lexerUnterminatedComment               ]
-        UnterminatedPurpose          -> [ Texts.lexerUnterminatedPurpose               ]
+        UnterminatedMarkup           -> [ Texts.lexerUnterminatedMarkup               ]
         UnterminatedAtom             -> [ Texts.lexerUnterminatedAtom                  ]
         UnexpectedChar c             -> [ Texts.lexerUnexpectedChar c                  ]
         NonTerminatedString _        -> [ Texts.lexerNonTerminatedString, correctStrings ]

--- a/src/Ampersand/Input/ADL1/LexerTexts.hs
+++ b/src/Ampersand/Input/ADL1/LexerTexts.hs
@@ -10,7 +10,7 @@ module Ampersand.Input.ADL1.LexerTexts
     , lexerUnexpectedClose
     , lexerUnterminatedAtom
     , lexerUnterminatedComment
-    , lexerUnterminatedPurpose
+    , lexerUnterminatedMarkup
     , lexerProblematicISO8601DateTime
     , lexerUtfChar
     ) where
@@ -43,11 +43,11 @@ lexerUnterminatedComment = select language
     , Dutch   :-> "Commentaar niet afgesloten"
     ]
 
--- | Translates 'Unterminated purpose' into the chosen language
-lexerUnterminatedPurpose:: String -- ^ The translated string
-lexerUnterminatedPurpose= select language
-    [ English :-> "Unterminated PURPOSE section"
-    , Dutch   :-> "PURPOSE sectie niet afgesloten"
+-- | Translates 'Unterminated markup' into the chosen language
+lexerUnterminatedMarkup:: String -- ^ The translated string
+lexerUnterminatedMarkup= select language
+    [ English :-> "Unterminated markup section. (any text between `{+` and `+}` )."
+    , Dutch   :-> "markup sectie niet afgesloten. (tekst tussen `{+` en `+}` )."
     ]
 
 -- | Translates 'Unterminated atom' into the chosen language

--- a/src/Ampersand/Input/ADL1/LexerToken.hs
+++ b/src/Ampersand/Input/ADL1/LexerToken.hs
@@ -25,7 +25,7 @@ data Lexeme  = LexSymbol      Char    -- ^ A symbol
              | LexOperator    String  -- ^ An operator
              | LexKeyword     String  -- ^ A keyword
              | LexString      String  -- ^ A quoted string
-             | LexExpl        String  -- ^ An explanation
+             | LexMarkup      String  -- ^ A markup (string to be parsed by Pandoc)
              | LexSingleton   String  -- ^ An atomvalue in an Expression
              | LexDecimal     Int     -- ^ A decimal number
              | LexFloat      Double   -- ^ A decimal floating point thing
@@ -43,7 +43,7 @@ instance Show Lexeme where
          LexOperator val -> "operator "              ++ "'"  ++      val  ++ "'"
          LexKeyword  val -> "keyword "               ++         show val
          LexString   val -> "string "                ++ "\"" ++      val  ++ "\""
-         LexExpl     val -> "explanation "           ++ "{+" ++      val  ++ "+}"
+         LexMarkup   val -> "markup "                ++ "{+" ++      val  ++ "+}"
          LexSingleton val -> "singleton "            ++ "'"  ++      val  ++ "'"
          LexDecimal   _  -> "integer "               ++   lexemeText  x
          LexFloat     _  -> "float "                 ++   lexemeText  x
@@ -69,7 +69,7 @@ lexemeText l = case l of
          LexOperator val -> val
          LexKeyword  val -> val
          LexString   val -> val
-         LexExpl     val -> val
+         LexMarkup   val -> val
          LexSingleton val -> val
          LexDecimal  val -> show val
          LexFloat    val -> show val

--- a/src/Ampersand/Input/ADL1/Parser.hs
+++ b/src/Ampersand/Input/ADL1/Parser.hs
@@ -478,12 +478,12 @@ pPhpplug = pKey "PHPPLUG" *> pObjDef
 --- Purpose ::= 'PURPOSE' Ref2Obj LanguageRef? TextMarkup? ('REF' StringListSemi)? Expl
 pPurpose :: AmpParser PPurpose
 pPurpose = rebuild <$> currPos
-                   <*  pKey "PURPOSE"  -- "EXPLAIN" has become obsolete
+                   <*  pKey "PURPOSE"
                    <*> pRef2Obj
                    <*> pMaybe pLanguageRef
                    <*> pMaybe pTextMarkup
                    <*> optList (pKey "REF" *> pString `sepBy1` pSemi)
-                   <*> pExpl
+                   <*> pAmpersandMarkup
      where
        rebuild :: Origin -> PRef2Obj -> Maybe Lang -> Maybe PandocFormat -> [String] -> String -> PPurpose
        rebuild    orig      obj         lang          fmt                   refs       str
@@ -554,7 +554,7 @@ pMeaning = PMeaning <$> (
            P_Markup <$  pKey "MEANING"
                     <*> pMaybe pLanguageRef
                     <*> pMaybe pTextMarkup
-                    <*> (pString <|> pExpl))
+                    <*> (pString <|> pAmpersandMarkup))
 
 --- Message ::= 'MESSAGE' Markup
 pMessage :: AmpParser PMessage
@@ -565,7 +565,7 @@ pMarkup :: AmpParser P_Markup
 pMarkup = P_Markup
            <$> pMaybe pLanguageRef
            <*> pMaybe pTextMarkup
-           <*> (pString <|> pExpl)
+           <*> (pString <|> pAmpersandMarkup)
 
 --- Rule ::= Term ('=' Term | '|-' Term)?
 -- | Parses a rule

--- a/src/Ampersand/Input/ADL1/Parser.hs
+++ b/src/Ampersand/Input/ADL1/Parser.hs
@@ -20,17 +20,17 @@ import Prelude hiding ((<$))
 pPopulations :: AmpParser [P_Population] -- ^ The population list parser
 pPopulations = many1 pPopulation
 
---- Context ::= 'CONTEXT' ConceptName LanguageRef TextMarkup? ContextElement* 'ENDCONTEXT'
+--- Context ::= 'CONTEXT' ConceptName LanguageRef? TextMarkup? ContextElement* 'ENDCONTEXT'
 -- | Parses a context
 pContext :: AmpParser (P_Context, [Include]) -- ^ The result is the parsed context and a list of include filenames
 pContext  = rebuild <$> posOf (pKey "CONTEXT")
                     <*> pConceptName
-                    <*> pLanguageRef
+                    <*> pMaybe pLanguageRef
                     <*> pMaybe pTextMarkup
                     <*> many pContextElement
                     <*  pKey "ENDCONTEXT"
   where
-    rebuild :: Origin -> String -> Lang -> Maybe PandocFormat -> [ContextElement] -> (P_Context, [Include])
+    rebuild :: Origin -> String -> Maybe Lang -> Maybe PandocFormat -> [ContextElement] -> (P_Context, [Include])
     rebuild    pos'      nm        lang          fmt                   ces
      = (PCtx{ ctx_nm     = nm
             , ctx_pos    = [pos']

--- a/src/Ampersand/Input/ADL1/ParsingLib.hs
+++ b/src/Ampersand/Input/ADL1/ParsingLib.hs
@@ -9,7 +9,7 @@ module Ampersand.Input.ADL1.ParsingLib(
     -- Positions
     currPos, posOf, valPosOf,
     -- Basic parsers
-    pConid, pString, pExpl, pVarid, pCrudString,
+    pConid, pString, pAmpersandMarkup, pVarid, pCrudString,
     -- special parsers
     pAtomInExpression, pAtomValInPopulation, Value(..),
     -- Special symbols
@@ -123,9 +123,9 @@ pConid = check (\lx -> case lx of { LexConId s -> Just s; _ -> Nothing }) <?> "u
 pString :: AmpParser String
 pString = check (\lx -> case lx of { LexString s -> Just s; _ -> Nothing }) <?> "string"
 
---- Expl ::= '{+' Any* '-}'
-pExpl :: AmpParser String
-pExpl = check (\lx -> case lx of { LexExpl s -> Just s; _ -> Nothing }) <?> "explanation"
+--- Markup ::= '{+' Any* '+}'
+pAmpersandMarkup :: AmpParser String
+pAmpersandMarkup = check (\lx -> case lx of { LexMarkup s -> Just s; _ -> Nothing }) <?> "markup"
 
 --- Varid ::= (LowerChar | '_') (Char | '_')*
 pVarid :: AmpParser String

--- a/src/Ampersand/Test/Parser/ArbitraryTree.hs
+++ b/src/Ampersand/Test/Parser/ArbitraryTree.hs
@@ -4,7 +4,7 @@ module Ampersand.Test.Parser.ArbitraryTree () where
 
 import Test.QuickCheck
 import Data.Char
-import Data.List (nub)
+import Data.List (nub,isInfixOf)
 import Ampersand.Core.ParseTree
 import Ampersand.Input.ADL1.Lexer (keywords)
 
@@ -343,7 +343,10 @@ instance Arbitrary Lang where
     arbitrary = elements [Dutch, English]
 
 instance Arbitrary P_Markup where
-    arbitrary = P_Markup <$> arbitrary <*> arbitrary <*> safeStr
+    arbitrary = P_Markup <$> arbitrary <*> arbitrary <*> safeStr `suchThat` noEndMarkup
+     where 
+       noEndMarkup :: String -> Bool
+       noEndMarkup = not . isInfixOf "+}"
 
 instance Arbitrary PandocFormat where
     arbitrary = elements [HTML, ReST, LaTeX, Markdown]

--- a/testing/Travis/testcases/Bugs/Current MultiFile/Bug388_Retina/RuntimeStuff.partialadl
+++ b/testing/Travis/testcases/Bugs/Current MultiFile/Bug388_Retina/RuntimeStuff.partialadl
@@ -5,7 +5,7 @@ PROCESS RuntimeStuff
 runtimeVerzamelendeService :: Persoonsgegeven * Service [UNI,TOT]
 PRAGMA "" " is verzameld door een instantie van "
 PURPOSE RELATION runtimeVerzamelendeService  REF "Artikel 7 Wbp"
-{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld. Om dit te kunnen doen moet voor elk persoonsgegeven de service geidentificeerd kunnen worden waarvan een instantie het persoonsgegeven heeft verzameld.-}
+{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld. Om dit te kunnen doen moet voor elk persoonsgegeven de service geidentificeerd kunnen worden waarvan een instantie het persoonsgegeven heeft verzameld.+}
 
 runtimeVerwerkendeService :: Persoonsgegeven * Service
 PRAGMA "" " is verwerkt door een instantie van "
@@ -28,7 +28,7 @@ MESSAGE ""
 VIOLATION (TXT "Persoonsgegeven ", SRC I, TXT " is verwerkt in runtime service '", TGT I, TXT "' zonder dat het verwerkingsdoel van de service verenigbaar is met de doeleinden waarvoor het persoonsgegeven is verkregen")
 ROLE User MAINTAINS "Verwerkingsdoelen"
 PURPOSE RULE "Verwerkingsdoelen" REF "Artikel 9 eerste lid Wbp"
-{+PERSOONSGEGEVENs worden niet verder verwerkt op een wijze die onverenigbaar is met de doeleinden waarvoor ze zijn verkregen.-}
+{+PERSOONSGEGEVENs worden niet verder verwerkt op een wijze die onverenigbaar is met de doeleinden waarvoor ze zijn verkregen.+}
 
 runtimeDoel :: SvcInstantie * RuntimeDoel
 
@@ -54,7 +54,7 @@ MESSAGE ""
 VIOLATION (TXT "Runtime verwerking '", SRC I, TXT "' dient geen doel en mag daarom niet plaatsvinden.")
 ROLE User MAINTAINS "Runtime verwerkingen hebben een doel"
 PURPOSE RULE "Runtime verwerkingen hebben een doel" REF "Artikel 9 eerste lid Wbp"
-{+PERSOONSGEGEVENs worden niet verder verwerkt op een wijze die onverenigbaar is met de doeleinden waarvoor ze zijn verkregen.-}
+{+PERSOONSGEGEVENs worden niet verder verwerkt op een wijze die onverenigbaar is met de doeleinden waarvoor ze zijn verkregen.+}
 
 ENDPROCESS
 ------------------------------------------------------------

--- a/testing/Travis/testcases/Bugs/Current MultiFile/Bug388_Retina/SystemStuff.partialadl
+++ b/testing/Travis/testcases/Bugs/Current MultiFile/Bug388_Retina/SystemStuff.partialadl
@@ -2,7 +2,7 @@ CONTEXT ServicesEnBerichten IN DUTCH
 -----------------------------------------------------------
 PROCESS "Services en berichten"
 PURPOSE PROCESS "Services en berichten" REF "Artikel 6 Wbp"
-{+PERSOONSGEGEVENs worden in overeenstemming met de wet en op behoorlijke en zorgvuldige wijze verwerkt (artikel 6 Wbp). Dit pattern bevat de eisen (requirements) voor geautomatiseerde gegevensverwerking teneinde aan dit artikel invulling te geven.-}
+{+PERSOONSGEGEVENs worden in overeenstemming met de wet en op behoorlijke en zorgvuldige wijze verwerkt (artikel 6 Wbp). Dit pattern bevat de eisen (requirements) voor geautomatiseerde gegevensverwerking teneinde aan dit artikel invulling te geven.+}
 
 --[Definetime]--
 
@@ -29,14 +29,14 @@ ROLE User MAINTAINS "Service omschrijven"
 
 svcVerantwoordelijke :: Service * Partij PRAGMA "Voor " " draagt " " (me)de verantwoordelijkheid in de zin van de Wbp"
 PURPOSE RELATION svcVerantwoordelijke REF "Artikel 1 sub d Wbp"
-{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder VERANTWOORDELIJKE: de natuurlijke persoon, rechtspersoon of ieder ander die of het bestuursorgaan dat, alleen of te zamen met anderen, het doel van en de middelen voor de VERWERKING vaststelt.-}
+{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder VERANTWOORDELIJKE: de natuurlijke persoon, rechtspersoon of ieder ander die of het bestuursorgaan dat, alleen of te zamen met anderen, het doel van en de middelen voor de VERWERKING vaststelt.+}
 PURPOSE RELATION svcVerantwoordelijke REF "Artikel 28 sub a Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de naam en het adres van de VERANTWOORDELIJKE.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de naam en het adres van de VERANTWOORDELIJKE.+}
 
 isDeelsvcVanVerwerking :: Service * Verwerking
 PRAGMA "" " is een onderdeel van "
 PURPOSE RELATION isDeelsvcVanVerwerking REF "Meldingsformulier Wbp en de Toelichting hierop"
-{+Op enig moment wordt (een deel van) een verwerking geautomatiseerd en ontstaat een Service. Om hierover te kunnen redeneren moeten we de relatie tussen verwerkingen en de geautomatiseerde componenten kennen.-}
+{+Op enig moment wordt (een deel van) een verwerking geautomatiseerd en ontstaat een Service. Om hierover te kunnen redeneren moeten we de relatie tussen verwerkingen en de geautomatiseerde componenten kennen.+}
 
 RULE "Service doel integriteit": 
    svcVerwerkingsDoel
@@ -47,7 +47,7 @@ MESSAGE ""
 VIOLATION (TXT "Service '", SRC I, TXT "' moet tenminste 1 doel hebben die een subdoel is van '", TGT I) 
 ROLE User MAINTAINS "Service doel integriteit"
 PURPOSE RULE "Service doel integriteit"
-{+Om te kunnen garanderen dat Services de juiste dingen doen, is het nodig om te eisen dat elk verwerkingsdoel van een service ofwel een doel dient van een service waarvan de eerste service een deelservice is, dan wel een doel dient van een verwerking waarvan die de service (deels) implementeert.-}
+{+Om te kunnen garanderen dat Services de juiste dingen doen, is het nodig om te eisen dat elk verwerkingsdoel van een service ofwel een doel dient van een service waarvan de eerste service een deelservice is, dan wel een doel dient van een verwerking waarvan die de service (deels) implementeert.+}
 
 RULE "Services implementeren verwerkingsdoelen": isDeelsvcVanVerwerking |- svcVerwerkingsDoel; (I \/ isSubdoelVan); verwerkingsDoel~
 MEANING "Elke service die een verwerking (deels) implementeert moet een doel nastreven dat gelijk is aan, of een subdoel is van het het doel van de verwerking"
@@ -55,13 +55,13 @@ MESSAGE ""
 VIOLATION (TXT "Service '", SRC I, TXT "' moet een doel hebben dat een (sub)doel is van '", TGT I) 
 ROLE User MAINTAINS "Services implementeren verwerkingsdoelen"
 PURPOSE RULE "Services implementeren verwerkingsdoelen"
-{+Om te kunnen beargumenteren dat een service een verwerking (deels) implementeert, moet de service een bijdrage leveren aan het doel van de verwerking. Deze bijdrage is een doel van de service, en daarmee een subdoel c.q. het doel van de verwerking.-}
+{+Om te kunnen beargumenteren dat een service een verwerking (deels) implementeert, moet de service een bijdrage leveren aan het doel van de verwerking. Deze bijdrage is een doel van de service, en daarmee een subdoel c.q. het doel van de verwerking.+}
 
 {-[IRF] overtredingen worden niet goed uitgerekend door prototypes-} --$Zie T#313**
 isDeelsvcVan :: Service * Service [{-IRF,-}ASY]
 PRAGMA "" " is een onderdeel van "
 PURPOSE RELATION isDeelsvcVan REF "Meldingsformulier Wbp en de Toelichting hierop"
-{+-}
+{++}
 
 {-IRF] overtredeingen worden niet goed uitgerekend door prototypes. Daarom doen we dit 'met de hand'-} --$Zie T#313**
 RULE "Irreflexiviteit van deelsvc zijn": I |- -isDeelsvcVan 
@@ -73,7 +73,7 @@ MESSAGE ""
 VIOLATION (TXT "Service '", SRC I, TXT "' moet tenminste 1 doel hebben die een subdoel is van '", TGT I) 
 ROLE User MAINTAINS "Deelservices dienen subdoelen"
 PURPOSE RULE "Deelservices dienen subdoelen"
-{+Om te kunnen beargumenteren dat een service wordt aangeroepen door (c.q. een deelservice is van) een andere service, moet die eerste een bijdrage leveren aan het doel van de tweede. Deze bijdrage is een doel van de eerste service, en dus ook een subdoel van een doel dat de tweede service beoogt. Merk op dat een soortgelijke doelsafhankelijkheid op runtime veel strakker is, omdat elke service instantie precies 1 doel dient.-}
+{+Om te kunnen beargumenteren dat een service wordt aangeroepen door (c.q. een deelservice is van) een andere service, moet die eerste een bijdrage leveren aan het doel van de tweede. Deze bijdrage is een doel van de eerste service, en dus ook een subdoel van een doel dat de tweede service beoogt. Merk op dat een soortgelijke doelsafhankelijkheid op runtime veel strakker is, omdat elke service instantie precies 1 doel dient.+}
 
 RULE "Serviceverantwoordelijkheidsintegriteit": svcVerantwoordelijke~; (I[Service] /\ -(isDeelsvcVan~;isDeelsvcVan)); svcVerantwoordelijke |- I[Partij]
 MEANING "Services die niet uit onderdelen bestaan hebben precies 1 verantwoordelijke (Toelichting Meldingsformulier Wbp)"
@@ -81,11 +81,11 @@ MESSAGE ""
 VIOLATION (TXT "Service '", SRC I, TXT "' heeft geen deelservices en moet daarom precies 1 verantwoordelijke hebben")
 ROLE User MAINTAINS "Serviceverantwoordelijkheidsintegriteit"
 PURPOSE RULE "Serviceverantwoordelijkheidsintegriteit" REF "Toelichting Meldingsformulier Wbp"
-{+Er kunnen bij een svc meerdere verantwoordelijken zijn. Is dat het geval, dan zal de onderlinge verdeling van verantwoordelijkheid tussen de verantwoordelijken duidelijk gemaakt moeten worden.-}
+{+Er kunnen bij een svc meerdere verantwoordelijken zijn. Is dat het geval, dan zal de onderlinge verdeling van verantwoordelijkheid tussen de verantwoordelijken duidelijk gemaakt moeten worden.+}
 
 svcBewerker :: Service * Partij PRAGMA "De feitelijke (runtime) uitvoering van " " is uitbesteed aan "
 PURPOSE RELATION svcBewerker REF "Artikel 1 sub e Wbp"
-{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder BEWERKER: degene die ten behoeve van de VERANTWOORDELIJKE PERSOONSGEGEVENs verwerkt, zonder aan zijn rechtstreeks gezag te zijn onderworpen.-}
+{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder BEWERKER: degene die ten behoeve van de VERANTWOORDELIJKE PERSOONSGEGEVENs verwerkt, zonder aan zijn rechtstreeks gezag te zijn onderworpen.+}
 
 RULE "Service bewerkers hebben verantwoordelijken": I /\ svcBewerker;svcBewerker~ |- svcVerantwoordelijke;svcVerantwoordelijke~
 MEANING "Voor elke bewerker moet de verantwoordelijkheid zijn belegd (Artikel 12 eerste lid Wbp)"
@@ -93,7 +93,7 @@ MESSAGE ""
 VIOLATION (TXT "Voor service '", SRC I, TXT " bestaat wel een verwerker, namelijk ", SRC svcBewerker, TXT ", maar er is geen verantwoordelijke")
 ROLE User MAINTAINS "Service bewerkers hebben verantwoordelijken" 
 PURPOSE RULE "Service bewerkers hebben verantwoordelijken" REF "Artikel 12 eerste lid Wbp"
-{+Een ieder die handelt onder het gezag van de VERANTWOORDELIJKE of van de BEWERKER, alsmede de BEWERKER zelf, voor zover deze toegang hebben tot PERSOONSGEGEVENs, verwerkt deze slechts in opdracht van de VERANTWOORDELIJKE, behoudens afwijkende wettelijke verplichtingen (artikel 12 eerste lid Wbp). Daarom moet per BEWERKER eenduidig bepaald kunnen worden wie de bijbehorende VERANTWOORDELIJKE is.-}
+{+Een ieder die handelt onder het gezag van de VERANTWOORDELIJKE of van de BEWERKER, alsmede de BEWERKER zelf, voor zover deze toegang hebben tot PERSOONSGEGEVENs, verwerkt deze slechts in opdracht van de VERANTWOORDELIJKE, behoudens afwijkende wettelijke verplichtingen (artikel 12 eerste lid Wbp). Daarom moet per BEWERKER eenduidig bepaald kunnen worden wie de bijbehorende VERANTWOORDELIJKE is.+}
 
 RULE "Service bewerkers hebben precies 1 verantwoordelijke": 
 {- Onderstaande regel kan gemakkelijker d.m.v.:
@@ -107,31 +107,31 @@ MESSAGE ""
 VIOLATION (TXT "Omdat service '", SRC I, TXT "' een verwerker heeft, namelijk ", SRC svcBewerker, TXT ", moet de verantwoordelijkheid eenduidig zijn belegd, en niet bij meerdere partijen, zoals ", SRC svcVerantwoordelijke)
 ROLE User MAINTAINS "Service bewerkers hebben precies 1 verantwoordelijke" 
 PURPOSE RULE "Service bewerkers hebben precies 1 verantwoordelijke" REF "Artikel 12 eerste lid Wbp"
-{+Een ieder die handelt onder het gezag van de VERANTWOORDELIJKE of van de BEWERKER, alsmede de BEWERKER zelf, voor zover deze toegang hebben tot PERSOONSGEGEVENs, verwerkt deze slechts in opdracht van de VERANTWOORDELIJKE, behoudens afwijkende wettelijke verplichtingen (artikel 12 eerste lid Wbp). Daarom moet per BEWERKER eenduidig bepaald kunnen worden wie de bijbehorende VERANTWOORDELIJKE is.-}
+{+Een ieder die handelt onder het gezag van de VERANTWOORDELIJKE of van de BEWERKER, alsmede de BEWERKER zelf, voor zover deze toegang hebben tot PERSOONSGEGEVENs, verwerkt deze slechts in opdracht van de VERANTWOORDELIJKE, behoudens afwijkende wettelijke verplichtingen (artikel 12 eerste lid Wbp). Daarom moet per BEWERKER eenduidig bepaald kunnen worden wie de bijbehorende VERANTWOORDELIJKE is.+}
 
 svcVerzamelDoel :: Service * Doel
 PRAGMA "" " verzamelt gegevens ten behoeve van "
 PURPOSE RELATION svcVerzamelDoel REF "Artikel 7 Wbp"
-{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld.-}
+{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld.+}
 
 svcVerwerkingsDoel :: Service * Doel
 PRAGMA "" " verwerkt gegevens ten behoeve van "
 PURPOSE RELATION svcVerwerkingsDoel REF "Artikel 11 eerste lid Wbp"
-{+PERSOONSGEGEVENs worden slechts verwerkt voor zover zij, gelet op de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt, toereikend, ter zake dienend en niet bovenmatig zijn. Daarom moet van elke service die persoonsgegevens verwerkt bekend zijn ten behoeve van welk(e) doel(en) die verwerking plaatsvindt.-}
+{+PERSOONSGEGEVENs worden slechts verwerkt voor zover zij, gelet op de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt, toereikend, ter zake dienend en niet bovenmatig zijn. Daarom moet van elke service die persoonsgegevens verwerkt bekend zijn ten behoeve van welk(e) doel(en) die verwerking plaatsvindt.+}
 PURPOSE RELATION svcVerwerkingsDoel REF "Artikel 28 sub b Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van het doel of de doeleinden van de svc.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van het doel of de doeleinden van de svc.+}
 
 RULE "Doel van services": I[Service] |- svcVerwerkingsDoel;svcVerwerkingsDoel~
 MEANING "Elke service dient tenminste 1 doel (Artikel 28 sub b Wbp)"
 MESSAGE ""
 VIOLATION (TXT "Voor service '", SRC I, TXT "' moet het/de doel(en) worden gespecificeerd.")
 PURPOSE RULE "Doel van services" REF "Artikel 28 sub b Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van het doel of de doeleinden van de svc.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van het doel of de doeleinden van de svc.+}
 
 svcVerzameltPersoonsgegevensType :: Service * PersoonsgegevensType
 PRAGMA "Service instanties van het type " " kunnen persoonsgegevens verzamelen van het type "
 PURPOSE RELATION svcVerzameltPersoonsgegevensType REF "Artikel 7 Wbp"
-{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld. Om dit te kunnen doen moeten de services geidentificeerd kunnen worden waarin het verzamelen van PERSOONSGEGEVENs plaatsvindt.-}
+{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld. Om dit te kunnen doen moeten de services geidentificeerd kunnen worden waarin het verzamelen van PERSOONSGEGEVENs plaatsvindt.+}
 
 svcVerwerktPersoonsgegevensType :: Service * PersoonsgegevensType
 PRAGMA "Service instanties van het type " " kunnen persoonsgegevens verwerken van het type "
@@ -158,7 +158,7 @@ MESSAGE ""
 VIOLATION (TXT "Persoonsgegevens van het type '", TGT I, TXT "' mogen niet worden verwerkt in service '", SRC I, TXT "' omdat ze kennelijk niet nodig zijn voor enig doel dat de service dient.")
 ROLE User MAINTAINS "Define time verwerkingsdoelen"
 PURPOSE RULE "Define time verwerkingsdoelen" REF "Artikel 11 eerste lid Wbp"
-{+PERSOONSGEGEVENs worden slechts verwerkt voor zover zij, gelet op de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt, toereikend, ter zake dienend en niet bovenmatig zijn.-}
+{+PERSOONSGEGEVENs worden slechts verwerkt voor zover zij, gelet op de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt, toereikend, ter zake dienend en niet bovenmatig zijn.+}
 
 RULE "Integriteit van het rechtvaardigen van verwerkingsdoelen": svcVerwerkingsDoel |- svcVerantwoordelijke; gerechtvaardigdDoor~
 MEANING "Als een service gegevens verwerkt ten behoeve van een zeker doel, dan moet dit doel zijn gerechtvaardigd door de VERANTWOORDELIJKE van de service."
@@ -166,7 +166,7 @@ MESSAGE ""
 VIOLATION (TXT "Van verwerking '", SRC I, TXT "' is het doel '", TGT I, TXT "' niet gerechtvaardigd door de service (verwerkings) verantwoordelijke (", SRC svcVerantwoordelijke, TXT ")")
 ROLE User MAINTAINS "Integriteit van het rechtvaardigen van verwerkingsdoelen"
 PURPOSE RULE "Integriteit van het rechtvaardigen van verwerkingsdoelen" REF "Artikel 1 sub d Wbp"
-{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder VERANTWOORDELIJKE: de natuurlijke persoon, rechtspersoon of ieder ander die of het bestuursorgaan dat, alleen of te zamen met anderen, het doel van en de middelen voor de VERWERKING vaststelt.-}
+{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder VERANTWOORDELIJKE: de natuurlijke persoon, rechtspersoon of ieder ander die of het bestuursorgaan dat, alleen of te zamen met anderen, het doel van en de middelen voor de VERWERKING vaststelt.+}
 
 svcVerstuurtBerichtSoort :: Service * BerichtSoort
 PRAGMA "Service instanties van de soort " " kunnen berichten versturen (= verwerken) van de soort "
@@ -178,12 +178,12 @@ MESSAGE ""
 VIOLATION (TXT "Service ", SRC I, TXT " moet gegevens van het type ", TGT I, TXT " (kunnen) hebben verwerkt, omdat die voorkomen in berichtsoort ", TGT berichtSoortGegevensType~)
 ROLE User MAINTAINS "Integriteit van versturen van berichten door services"
 PURPOSE RULE "Integriteit van versturen van berichten door services" REF "Artikel 11 eerste lid Wbp"
-{+PERSOONSGEGEVENs worden slechts verwerkt voor zover zij, gelet op de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt, toereikend, ter zake dienend en niet bovenmatig zijn. -}
+{+PERSOONSGEGEVENs worden slechts verwerkt voor zover zij, gelet op de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt, toereikend, ter zake dienend en niet bovenmatig zijn. +}
 
 svcOntvangtBerichtSoort :: Service * BerichtSoort
 PRAGMA "Service instanties van de soort " " kunnen berichten ontvangen (= verwerken) van de soort "
 PURPOSE RELATION svcOntvangtBerichtSoort REF "Artikel 1 sub h Wbp"
-{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder ONTVANGER: degene aan wie de PERSOONSGEGEVENs worden verstrekt.-}
+{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder ONTVANGER: degene aan wie de PERSOONSGEGEVENs worden verstrekt.+}
 
 RULE "Integriteit van ontvangen van berichten door services": 
 svcOntvangtBerichtSoort; berichtSoortGegevensType |- svcVerwerktPersoonsgegevensType
@@ -192,12 +192,12 @@ MESSAGE ""
 VIOLATION (TXT "Service ", SRC I, TXT " moet gegevens van het type ", TGT I, TXT " kunnen verwerken, omdat die voorkomen in berichtsoort ", TGT berichtSoortGegevensType~)
 ROLE User MAINTAINS "Integriteit van ontvangen van berichten door services"
 PURPOSE RULE "Integriteit van ontvangen van berichten door services" REF "Artikel 11 eerste lid Wbp"
-{+PERSOONSGEGEVENs worden slechts verwerkt voor zover zij, gelet op de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt, toereikend, ter zake dienend en niet bovenmatig zijn. -}
+{+PERSOONSGEGEVENs worden slechts verwerkt voor zover zij, gelet op de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt, toereikend, ter zake dienend en niet bovenmatig zijn. +}
 
 svcSpecificatieSamenvatting :: Service * SpecificatieSamenvatting
 PRAGMA "Een algemene beschrijving om een voorlopig oordeel te kunnen geven over de gepastheid van de voorgenomen maatregelen om, ter toepassing van artikel 13 en 14, de beveiliging van " " te waarborgen, wordt gegeven door"
 PURPOSE RELATION verwerkingSpecificatieSamenvatting REF "Artikel 28 sub f Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van een algemene beschrijving om een voorlopig oordeel te kunnen geven over de gepastheid van de voorgenomen maatregelen om, ter toepassing van artikel 13 en 14, de beveiliging van de verwerking te waarborgen.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van een algemene beschrijving om een voorlopig oordeel te kunnen geven over de gepastheid van de voorgenomen maatregelen om, ter toepassing van artikel 13 en 14, de beveiliging van de verwerking te waarborgen.+}
 
 --[Typeringen]--
 

--- a/testing/Travis/testcases/Bugs/Current MultiFile/Bug388_Retina/WBP-Ontologie.partialadl
+++ b/testing/Travis/testcases/Bugs/Current MultiFile/Bug388_Retina/WBP-Ontologie.partialadl
@@ -163,7 +163,7 @@ verwerkingBewaartermijn :: Verwerking * Bewaartermijn [UNI] PRAGMA "De periode g
 PURPOSE RELATION verwerkingBewaartermijn REF "Artikel 10 Wbp"
 {+1.	PERSOONSGEGEVENs worden niet langer bewaard in een vorm die het mogelijk maakt de BETROKKENE te identificeren, dan noodzakelijk is voor de verwerkelijking van de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt.
 2.	PERSOONSGEGEVENs mogen langer worden bewaard dan bepaald in het eerste lid voor zover ze voor historische, statistische of wetenschappelijke doeleinden worden bewaard, en de VERANTWOORDELIJKE de nodige voorzieningen heeft getroffen ten einde te verzekeren dat de desbetreffende gegevens uitsluitend voor deze specifieke doeleinden worden gebruikt.
--}
++}
 
 --[Doelen]--
 
@@ -190,13 +190,13 @@ c.	2. ten behoeve van de uitvoering van de politietaak, bedoeld in de artikelen 
 d.	die is geregeld bij of krachtens de Wet gemeentelijke basisadministratie persoonsgegevens;
 e.	ten behoeve van de uitvoering van de Wet justitiële en strafvorderlijke gegevens en
 f.	ten behoeve van de uitvoering van de Kieswet.
--}
++}
 PURPOSE RELATION doelWettelijkeGrondslag REF "Artikel 2 derde lid Wbp"
 {+Een van de grondslagen op basis waarvan VERWERKINGen (kunnen) zijn toegestaan, althans niet zijn verboden, is als de Wbp niet van toepassing is. Deze wet is niet van toepassing is op VERWERKING door de krijgsmacht indien Onze Minister van Defensie daartoe beslist met het oog op de inzet of het ter beschikking stellen van de krijgsmacht ter handhaving of bevordering van de internationale rechtsorde.
--}
++}
 PURPOSE RELATION doelWettelijkeGrondslag REF "Artikel 3 eerste lid Wbp"
 {+Een van de grondslagen op basis waarvan VERWERKINGen (kunnen) zijn toegestaan, althans niet zijn verboden, is als de Wbp niet van toepassing is. Deze wet is niet van toepassing op de VERWERKING voor uitsluitend journalistieke, artistieke of literaire doeleinden, behoudens de overige bepalingen van hoofdstuk 1 Wbp, alsmede de artikelen 6 tot en met 11, 13 tot en met 15, 25 en 49 van die wet.
--}
++}
 
 isSubdoelVan :: Doel * Doel [ASY]
 PRAGMA "Het bereiken van " " is een onderdeel van het bereiken van "

--- a/testing/Travis/testcases/Bugs/Current MultiFile/Bug388_Retina/WBP-Ontologie.partialadl
+++ b/testing/Travis/testcases/Bugs/Current MultiFile/Bug388_Retina/WBP-Ontologie.partialadl
@@ -2,7 +2,7 @@ CONTEXT WBPOntologie IN DUTCH
 -----------------------------------------------------------
 PROCESS "Wbp Hoofdstuk 1 (uitgezonderd paragraaf 2)"
 PURPOSE PROCESS "Wbp Hoofdstuk 1 (uitgezonderd paragraaf 2)"
-{+Dit pattern bevat de terminologie (en de relaties daartussen) welke aansluiten op de Wet Bescherming Persoonsgegevens (Wbp), althans (en vooralsnog) de artikelen 1 t/m 15, en voorzover deze nodig zijn voor het werkwerken van persoonsgegevens bij volledig geautomatiseerde systemen (dat is immers de scope van ons onderzoek). De wet zelf is van toepassing op elke geheel of gedeeltelijk geautomatiseerde verwerking van persoonsgegevens, alsmede op elke niet geautomatiseerde verwerking van persoonsgegevens die in een bestand zijn opgenomen of die bestemd zijn om daarin te worden opgenomen (artikel 2 eerste lid Wbp). Dit pattern definieert een mapping tussen de tekst van de wet en een formele ontologie voor ons systeem.-}
+{+Dit pattern bevat de terminologie (en de relaties daartussen) welke aansluiten op de Wet Bescherming Persoonsgegevens (Wbp), althans (en vooralsnog) de artikelen 1 t/m 15, en voorzover deze nodig zijn voor het werkwerken van persoonsgegevens bij volledig geautomatiseerde systemen (dat is immers de scope van ons onderzoek). De wet zelf is van toepassing op elke geheel of gedeeltelijk geautomatiseerde verwerking van persoonsgegevens, alsmede op elke niet geautomatiseerde verwerking van persoonsgegevens die in een bestand zijn opgenomen of die bestemd zijn om daarin te worden opgenomen (artikel 2 eerste lid Wbp). Dit pattern definieert een mapping tussen de tekst van de wet en een formele ontologie voor ons systeem.+}
 
 --[Persoonsgegevens]--
 
@@ -17,12 +17,12 @@ persoonsgegevensWaarde :: Persoonsgegeven -> PersoonsgegevensWaarde
 betrokkene :: Persoonsgegeven * NatuurlijkPersoon [UNI,TOT]
 PRAGMA "" " is een gegeven betreffende " ", die (mede) aan de hand van dit gegeven geidentificeerd is of indentificeerbaar is"
 PURPOSE RELATION betrokkene REF "Artikel 1 sub f Wbp"
-{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder BETROKKENE: degene op wie een persoonsgegeven betrekking heeft.-}
+{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder BETROKKENE: degene op wie een persoonsgegeven betrekking heeft.+}
 
 verzamelDoel :: Persoonsgegeven * Doel
 PRAGMA "" " is verzameld ten behoeve van "
 PURPOSE RELATION verzamelDoel REF "Artikel 7 Wbp"
-{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld.-}
+{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld.+}
 
 RULE "Integriteit van het verzamelen van persoonsgegevens" : 
 I[Persoonsgegeven] |- verzamelDoel;verzamelDoel~
@@ -31,13 +31,13 @@ MESSAGE "Persoonsgegevens worden alleen verzameld ten behoeve van een (welbepaal
 VIOLATION (TXT "Van persoonsgegeven ", SRC I, TXT " is geen doel bekend waartoe het is verzameld")
 ROLE User MAINTAINS "Integriteit van het verzamelen van persoonsgegevens"
 PURPOSE RULE "Integriteit van het verzamelen van persoonsgegevens" REF "Artikel 7 Wbp"
-{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld.-}
+{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld.+}
 
 --[Verwerkingen]--
 
 CONCEPT Verwerking "de specificatie van een geheel aan (runtime) handelingen als bedoeld in artikel 1 sub b Wbp, ten behoeve van een (of meerdere) doel(einden)" ""
 PURPOSE CONCEPT Verwerking REF "Artikel 1 sub b Wbp"
-{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder VERWERKING: elke handeling of elk geheel van handelingen met betrekking tot PERSOONSGEGEVENs, waaronder in ieder geval het verzamelen, vastleggen, ordenen, bewaren, bijwerken, wijzigen, opvragen, raadplegen, gebruiken, verstrekken door middel van doorzending, verspreiding of enige andere vorm van terbeschikkingstelling, samenbrengen, met elkaar in verband brengen, alsmede het afschermen, uitwissen of vernietigen van gegevens.-}
+{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder VERWERKING: elke handeling of elk geheel van handelingen met betrekking tot PERSOONSGEGEVENs, waaronder in ieder geval het verzamelen, vastleggen, ordenen, bewaren, bijwerken, wijzigen, opvragen, raadplegen, gebruiken, verstrekken door middel van doorzending, verspreiding of enige andere vorm van terbeschikkingstelling, samenbrengen, met elkaar in verband brengen, alsmede het afschermen, uitwissen of vernietigen van gegevens.+}
 VIEW "Verwerkingen": Verwerking(verwerkingNaam)
 verwerkingNaam :: Verwerking * Naam  [UNI,TOT] PRAGMA "" " wordt door diens verantwoordelijke aangeduid als "
 verwerkingOmschrijving :: Verwerking * Omschrijving PRAGMA "" " wordt omschreven als "
@@ -49,9 +49,9 @@ ROLE User MAINTAINS "Verwerking omschrijven"
 
 verwerkingsVerantwoordelijke :: Verwerking * Partij PRAGMA "Voor " " draagt " " (me)de verantwoordelijkheid in de zin van de Wbp"
 PURPOSE RELATION verwerkingsVerantwoordelijke REF "Artikel 1 sub d Wbp"
-{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder VERANTWOORDELIJKE: de natuurlijke persoon, rechtspersoon of ieder ander die of het bestuursorgaan dat, alleen of te zamen met anderen, het doel van en de middelen voor de VERWERKING vaststelt.-}
+{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder VERANTWOORDELIJKE: de natuurlijke persoon, rechtspersoon of ieder ander die of het bestuursorgaan dat, alleen of te zamen met anderen, het doel van en de middelen voor de VERWERKING vaststelt.+}
 PURPOSE RELATION verwerkingsVerantwoordelijke REF "Artikel 28 sub a Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de naam en het adres van de VERANTWOORDELIJKE.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de naam en het adres van de VERANTWOORDELIJKE.+}
 
 RULE "Verwerkingsverantwoordelijkheid toekennen": I[Verwerking] |- verwerkingsVerantwoordelijke;verwerkingsVerantwoordelijke~
 MEANING "Elke verwerking moet een VERANTWOORDELIJKE hebben (Artikel 1 sub d Wbp)"
@@ -59,13 +59,13 @@ MESSAGE ""
 VIOLATION (TXT "Van verwerking '", SRC I, TXT "' moet de Verantwoordelijke worden ingevuld")
 ROLE User MAINTAINS "Verwerkingsverantwoordelijkheid toekennen"
 PURPOSE RULE "Verwerkingsverantwoordelijkheid toekennen" REF "Artikel 1 sub d Wbp"
-{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder VERANTWOORDELIJKE: de natuurlijke persoon, rechtspersoon of ieder ander die of het bestuursorgaan dat, alleen of te zamen met anderen, het doel van en de middelen voor de VERWERKING vaststelt. Dat kan alleen als aan elke VERWERKING een VERANTWOORDELIJKE is toegekend-}
+{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder VERANTWOORDELIJKE: de natuurlijke persoon, rechtspersoon of ieder ander die of het bestuursorgaan dat, alleen of te zamen met anderen, het doel van en de middelen voor de VERWERKING vaststelt. Dat kan alleen als aan elke VERWERKING een VERANTWOORDELIJKE is toegekend+}
 
 {-[IRF] overtredingen worden niet goed uitgerekend door prototypes-} --$Zie T#313**
 isDeelverwerkingVan :: Verwerking * Verwerking [{-IRF,-}ASY]
 PRAGMA "" " is een onderdeel van "
 PURPOSE RELATION isDeelverwerkingVan REF "Meldingsformulier Wbp en de Toelichting hierop"
-{+-}
+{++}
 
 {-IRF] overtredeingen worden niet goed uitgerekend door prototypes. Daarom doen we dit 'met de hand'-} --$Zie T#313**
 RULE "Irreflexiviteit van deelverwerking zijn": I |- -isDeelverwerkingVan 
@@ -78,7 +78,7 @@ MESSAGE ""
 VIOLATION (TXT "Verwerking '", SRC I, TXT "' moet tenminste 1 doel hebben die een subdoel is van '", TGT I) 
 ROLE User MAINTAINS "Deelverwerkingen dienen subdoelen"
 PURPOSE RULE "Deelverwerkingen dienen subdoelen"
-{+Om te kunnen beargumenteren dat een verwerking wordt aangeroepen door (c.q. een deelverwerking is van) een andere verwerking, moet die eerste een bijdrage leveren aan het doel van de tweede. Deze bijdrage is een doel van de eerste verwerking, en dus ook een subdoel van een doel dat de tweede verwerking beoogt. Merk op dat een soortgelijke doelsafhankelijkheid op runtime veel strakker is, omdat elke verwerkingsinstantie precies 1 doel dient.-}
+{+Om te kunnen beargumenteren dat een verwerking wordt aangeroepen door (c.q. een deelverwerking is van) een andere verwerking, moet die eerste een bijdrage leveren aan het doel van de tweede. Deze bijdrage is een doel van de eerste verwerking, en dus ook een subdoel van een doel dat de tweede verwerking beoogt. Merk op dat een soortgelijke doelsafhankelijkheid op runtime veel strakker is, omdat elke verwerkingsinstantie precies 1 doel dient.+}
 
 RULE "Verwerkingsverantwoordelijkheidsintegriteit": verwerkingsVerantwoordelijke~; (I[Verwerking] /\ -(isDeelverwerkingVan~;isDeelverwerkingVan)); verwerkingsVerantwoordelijke |- I[Partij]
 MEANING "Verwerkingen die niet uit onderdelen bestaan hebben precies 1 verantwoordelijke (Toelichting Meldingsformulier Wbp)"
@@ -86,11 +86,11 @@ MESSAGE ""
 VIOLATION (TXT "Verwerking '", SRC I, TXT "' heeft geen deelverwerkingen en moet daarom precies 1 verantwoordelijke hebben")
 ROLE User MAINTAINS "Verwerkingsverantwoordelijkheidsintegriteit"
 PURPOSE RULE "Verwerkingsverantwoordelijkheidsintegriteit" REF "Toelichting Meldingsformulier Wbp"
-{+Er kunnen bij een verwerking meerdere verantwoordelijken zijn. Is dat het geval, dan zal de onderlinge verdeling van verantwoordelijkheid tussen de verantwoordelijken duidelijk gemaakt moeten worden.-}
+{+Er kunnen bij een verwerking meerdere verantwoordelijken zijn. Is dat het geval, dan zal de onderlinge verdeling van verantwoordelijkheid tussen de verantwoordelijken duidelijk gemaakt moeten worden.+}
 
 verwerkingBewerker :: Verwerking * Partij PRAGMA "De feitelijke (runtime) uitvoering van " " is uitbesteed aan "
 PURPOSE RELATION verwerkingBewerker REF "Artikel 1 sub e Wbp"
-{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder BEWERKER: degene die ten behoeve van de VERANTWOORDELIJKE PERSOONSGEGEVENs verwerkt, zonder aan zijn rechtstreeks gezag te zijn onderworpen.-}
+{+In de Wbp en de daarop berustende bepalingen wordt verstaan onder BEWERKER: degene die ten behoeve van de VERANTWOORDELIJKE PERSOONSGEGEVENs verwerkt, zonder aan zijn rechtstreeks gezag te zijn onderworpen.+}
 
 RULE "Bewerkers hebben verantwoordelijken": I /\ verwerkingBewerker;verwerkingBewerker~ |- verwerkingsVerantwoordelijke;verwerkingsVerantwoordelijke~
 MEANING "Voor elke bewerker moet de verantwoordelijkheid zijn belegd (Artikel 12 eerste lid Wbp)"
@@ -98,7 +98,7 @@ MESSAGE ""
 VIOLATION (TXT "Voor verwerking '", SRC I, TXT " bestaat wel een verwerker, namelijk ", SRC verwerkingBewerker, TXT ", maar er is geen verantwoordelijke")
 ROLE User MAINTAINS "Bewerkers hebben verantwoordelijken" 
 PURPOSE RULE "Bewerkers hebben verantwoordelijken" REF "Artikel 12 eerste lid Wbp"
-{+Een ieder die handelt onder het gezag van de VERANTWOORDELIJKE of van de BEWERKER, alsmede de BEWERKER zelf, voor zover deze toegang hebben tot PERSOONSGEGEVENs, verwerkt deze slechts in opdracht van de VERANTWOORDELIJKE, behoudens afwijkende wettelijke verplichtingen (artikel 12 eerste lid Wbp). Daarom moet per BEWERKER eenduidig bepaald kunnen worden wie de bijbehorende VERANTWOORDELIJKE is.-}
+{+Een ieder die handelt onder het gezag van de VERANTWOORDELIJKE of van de BEWERKER, alsmede de BEWERKER zelf, voor zover deze toegang hebben tot PERSOONSGEGEVENs, verwerkt deze slechts in opdracht van de VERANTWOORDELIJKE, behoudens afwijkende wettelijke verplichtingen (artikel 12 eerste lid Wbp). Daarom moet per BEWERKER eenduidig bepaald kunnen worden wie de bijbehorende VERANTWOORDELIJKE is.+}
 
 RULE "Bewerkers hebben precies 1 verantwoordelijke": 
 {- Onderstaande regel kan gemakkelijker d.m.v.:
@@ -112,14 +112,14 @@ MESSAGE ""
 VIOLATION (TXT "Omdat verwerking '", SRC I, TXT "' een verwerker heeft, namelijk ", SRC verwerkingBewerker, TXT ", moet de verantwoordelijkheid eenduidig zijn belegd, en niet bij meerdere partijen, zoals ", SRC verwerkingsVerantwoordelijke)
 ROLE User MAINTAINS "Bewerkers hebben precies 1 verantwoordelijke" 
 PURPOSE RULE "Bewerkers hebben precies 1 verantwoordelijke" REF "Artikel 12 eerste lid Wbp"
-{+Een ieder die handelt onder het gezag van de VERANTWOORDELIJKE of van de BEWERKER, alsmede de BEWERKER zelf, voor zover deze toegang hebben tot PERSOONSGEGEVENs, verwerkt deze slechts in opdracht van de VERANTWOORDELIJKE, behoudens afwijkende wettelijke verplichtingen (artikel 12 eerste lid Wbp). Daarom moet per BEWERKER eenduidig bepaald kunnen worden wie de bijbehorende VERANTWOORDELIJKE is.-}
+{+Een ieder die handelt onder het gezag van de VERANTWOORDELIJKE of van de BEWERKER, alsmede de BEWERKER zelf, voor zover deze toegang hebben tot PERSOONSGEGEVENs, verwerkt deze slechts in opdracht van de VERANTWOORDELIJKE, behoudens afwijkende wettelijke verplichtingen (artikel 12 eerste lid Wbp). Daarom moet per BEWERKER eenduidig bepaald kunnen worden wie de bijbehorende VERANTWOORDELIJKE is.+}
 
 verwerkingsDoel :: Verwerking * Doel
 PRAGMA "" " verwerkt gegevens ten behoeve van "
 PURPOSE RELATION svcVerwerkingsDoel REF "Artikel 11 eerste lid Wbp"
-{+PERSOONSGEGEVENs worden slechts verwerkt voor zover zij, gelet op de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt, toereikend, ter zake dienend en niet bovenmatig zijn. Daarom moet van elke verwering bekend zijn ten behoeve van welk(e) doel(en) die plaatsvindt.-}
+{+PERSOONSGEGEVENs worden slechts verwerkt voor zover zij, gelet op de doeleinden waarvoor zij worden verzameld of vervolgens worden verwerkt, toereikend, ter zake dienend en niet bovenmatig zijn. Daarom moet van elke verwering bekend zijn ten behoeve van welk(e) doel(en) die plaatsvindt.+}
 PURPOSE RELATION verwerkingsDoel REF "Artikel 28 sub b Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van het doel of de doeleinden van de verwerking.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van het doel of de doeleinden van de verwerking.+}
 
 RULE "Doel van verwerkingen": I[Verwerking] |- verwerkingsDoel;verwerkingsDoel~
 MEANING "Elke verwerking dient tenminste 1 doel (Artikel 28 sub b Wbp)"
@@ -127,37 +127,37 @@ MESSAGE ""
 VIOLATION (TXT "Voor verwerking '", SRC I, TXT "' moet het doel (c.q. de doelen) worden gespecificeerd.")
 ROLE User MAINTAINS "Doel van verwerkingen"
 PURPOSE RULE "Doel van verwerkingen" REF "Artikel 28 sub b Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van het doel of de doeleinden van de verwerking.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van het doel of de doeleinden van de verwerking.+}
 
 verwerkingBetrokkenenCategorie :: Verwerking * BetrokkeneCategorie
 PRAGMA "" " verzamelt en/of verwerkt gegevens met betrekking tot betrokkenen die behoren tot "
 PURPOSE RELATION verwerkingBetrokkenenCategorie REF "Artikel 28 sub c Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van een beschrijving van de categorieën van BETROKKENEn en van de gegevens of categorieën van gegevens die daarop betrekking hebben.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van een beschrijving van de categorieën van BETROKKENEn en van de gegevens of categorieën van gegevens die daarop betrekking hebben.+}
 
 verwerkingGegevensCategorie :: Verwerking * GegevensCategorie
 PRAGMA "" " verzamelt en/of verwerkt gegevens die behoren tot "
 PURPOSE RELATION verwerkingGegevensCategorie REF "Artikel 28 sub c Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van een beschrijving van de categorieën van BETROKKENEn en van de gegevens of categorieën van gegevens die daarop betrekking hebben.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van een beschrijving van de categorieën van BETROKKENEn en van de gegevens of categorieën van gegevens die daarop betrekking hebben.+}
 
 verwerkingOntvangerCategorie :: Verwerking * OntvangerCategorie
 PRAGMA "" " verstrekt gegevens aan partijen die behoren tot "
 PURPOSE RELATION verwerkingOntvangerCategorie REF "Artikel 28 sub d Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de ONTVANGERs of categorieën van ONTVANGERs aan wie de gegevens kunnen worden verstrekt.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de ONTVANGERs of categorieën van ONTVANGERs aan wie de gegevens kunnen worden verstrekt.+}
 
 verwerkingOntvanger :: Verwerking * Partij 
 PRAGMA "" " verstrekt gegevens aan "
 PURPOSE RELATION verwerkingOntvanger REF "Artikel 28 sub d Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de ONTVANGERs of categorieën van ONTVANGERs aan wie de gegevens kunnen worden verstrekt.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de ONTVANGERs of categorieën van ONTVANGERs aan wie de gegevens kunnen worden verstrekt.+}
 
 verwerkingGegevensDoorgiftenBuitenEU :: Verwerking * DoorgifteBuitenEU 
 PRAGMA "" " geeft gegevens door aan " " (buiten de EU)"
 PURPOSE RELATION verwerkingGegevensDoorgiftenBuitenEU REF "Artikel 28 sub e Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de voorgenomen doorgiften van gegevens naar landen buiten de Europese Unie.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de voorgenomen doorgiften van gegevens naar landen buiten de Europese Unie.+}
 
 verwerkingSpecificatieSamenvatting :: Verwerking * SpecificatieSamenvatting [UNI] 
 PRAGMA "Een algemene beschrijving om een voorlopig oordeel te kunnen geven over de gepastheid van de voorgenomen maatregelen om, ter toepassing van artikel 13 en 14, de beveiliging van " " te waarborgen, wordt gegeven door"
 PURPOSE RELATION verwerkingSpecificatieSamenvatting REF "Artikel 28 sub f Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van een algemene beschrijving om een voorlopig oordeel te kunnen geven over de gepastheid van de voorgenomen maatregelen om, ter toepassing van artikel 13 en 14, de beveiliging van de verwerking te waarborgen.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van een algemene beschrijving om een voorlopig oordeel te kunnen geven over de gepastheid van de voorgenomen maatregelen om, ter toepassing van artikel 13 en 14, de beveiliging van de verwerking te waarborgen.+}
 
 verwerkingBewaartermijn :: Verwerking * Bewaartermijn [UNI] PRAGMA "De periode gedurende welke de gegevens welke in " " worden verwerkt, worden bewaard, bedraagt "
 PURPOSE RELATION verwerkingBewaartermijn REF "Artikel 10 Wbp"
@@ -174,11 +174,11 @@ doelID :: Doel -> DoelID PRAGMA "" " wordt aangeduid door "
 gerechtvaardigdDoor :: Doel * Partij [UNI] 
 PRAGMA "" " is gerechtvaardigd door "
 PURPOSE RELATION gerechtvaardigdDoor REF "Artikel 7 resp artikel 8 Wbp"
-{+Aritkel 7 stelt:PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld. Artikel 8 stelt beperkingen aan andersoortige verwerkingen.-}
+{+Aritkel 7 stelt:PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld. Artikel 8 stelt beperkingen aan andersoortige verwerkingen.+}
 
 doelOmschrijving :: Doel * Omschrijving [UNI] PRAGMA "" " is welbepaald en wordt uitdrukkelijk omschreven door "
 PURPOSE RELATION doelOmschrijving REF "Artikel 7 Wbp"
-{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld.-}
+{+PERSOONSGEGEVENs worden voor welbepaalde, uitdrukkelijk omschreven en gerechtvaardigde doeleinden verzameld.+}
 
 doelWettelijkeGrondslag :: Doel * WettelijkeGrondslag [UNI]
 PRAGMA "De wettelijke basis voor " " is "
@@ -223,13 +223,13 @@ PRAGMA "Om " " te kunnen bereiken is het verwerken van gegevens van het type " "
 verenigbaarMet :: Doel * Doel
 PRAGMA "Het verzameldoel " " is (volgens de VERANTWOORDELIJKE) verenigbaar met verwerkingsdoel "
 PURPOSE RELATION verenigbaarMet REF "Artikel 9 eerste lid Wbp"
-{+PERSOONSGEGEVENs worden niet verder verwerkt op een wijze die onverenigbaar is met de doeleinden waarvoor ze zijn verkregen.-}
+{+PERSOONSGEGEVENs worden niet verder verwerkt op een wijze die onverenigbaar is met de doeleinden waarvoor ze zijn verkregen.+}
 
 ENDPROCESS
 --[Partijen]-----------------------------------------------
 PROCESS "Partijen"
 PURPOSE PROCESS "Partijen"
-{+Om te kunnen praten over de concrete personen, rechtspersonen, bestuursorganen e.d. die een rol kunnen vervullen zoals de Wbp die noemt (bijvoorbeeld 'Verantwoordelijke' of 'Bewerker'), hebben we een concept nodig waarmee we instaties van die rollen kunnen weergeven.-}
+{+Om te kunnen praten over de concrete personen, rechtspersonen, bestuursorganen e.d. die een rol kunnen vervullen zoals de Wbp die noemt (bijvoorbeeld 'Verantwoordelijke' of 'Bewerker'), hebben we een concept nodig waarmee we instaties van die rollen kunnen weergeven.+}
 
 CONCEPT Partij "Een natuurlijke persoon, rechtspersoon, bestuursorgaan of ieder ander die de rol van VERANTWOORDELIJKE, BEWERKER, BETROKKENE, ONTVANGER of DERDE kan vervullen."
 IDENT "Partijen": Partij(partijNaam)
@@ -243,7 +243,7 @@ MEANING "Van elke VERANTWOORDELIJKE moet de naam en het adres bekend zijn (Artik
 MESSAGE ""
 VIOLATION (TXT "Van ", SRC I, TXT " moet de naam en het adres bekend zijn")
 PURPOSE RULE "Integriteit voor partijen die VERANTWOORDELIJKE zijn" REF "Artikel 28 sub a Wbp"
-{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de naam en het adres van de VERANTWOORDELIJKE.-}
+{+Een melding van een (geheel of gedeeltelijk geautomatiseerde VERWERKING) als bedoeld in Artikel 27 eerste lid, behelst een opgave van de naam en het adres van de VERANTWOORDELIJKE.+}
 
 ENDPROCESS
 -----------------------------------------------------------

--- a/testing/Travis/testcases/FuncSpec/Mandatering/Mandatering.adl
+++ b/testing/Travis/testcases/FuncSpec/Mandatering/Mandatering.adl
@@ -155,7 +155,7 @@ Dat impliceert dat een besluit altijd in naam van een bestuursorgaan wordt genom
   RULE "Artikel 10:10 Awb" : krachtens;namens |- beslotenDoor
   MEANING "De Awb zegt dat: een krachtens mandaat genomen besluit vermeldt namens welk bestuursorgaan het besluit is genomen. Dat impliceert dat een besluit altijd in naam van een bestuursorgaan wordt genomen"
   PURPOSE RULE "Artikel 10:10 Awb" REF "Artikel 10:10 Awb"
-{+De Awb zegt dat een krachtens mandaat genomen besluit vermeldt namens welk bestuursorgaan het besluit is genomen. Dat impliceert dat een besluit altijd in naam van een bestuursorgaan wordt genomen. -}
+{+De Awb zegt dat een krachtens mandaat genomen besluit vermeldt namens welk bestuursorgaan het besluit is genomen. Dat impliceert dat een besluit altijd in naam van een bestuursorgaan wordt genomen. +}
 
 
    -- bevoegdheid hernoemd naar mandaatbevoegdheid omdat bevoegdheid al bestaat

--- a/testing/Travis/testcases/Misc/Arbeidsduur.adl
+++ b/testing/Travis/testcases/Misc/Arbeidsduur.adl
@@ -1,7 +1,7 @@
 CONTEXT Arbeidsduur IN DUTCH LATEX
 META "authors" "Stef Joosten, Rieks Joosten"
 PURPOSE CONTEXT Arbeidsduur
-{+De Wet aanpassing arbeidsduur (http://wetten.overheid.nl/BWBR0011173, 19 februari 2000) regelt het recht van werknemers om te vragen om aanpassing van de arbeidsduur. Op deze wet is een Ampersand analyse gedaan, om inzicht te krijgen in de wijze van modelleren aan de hand van een klein voorbeeld. Daar waar in deze tekst wordt gerefereerd naar een wetsartikel, zonder de naam van de wet erbij te noemen, wordt de Wet aanpassing arbeidsduur bedoeld.-}
+{+De Wet aanpassing arbeidsduur (http://wetten.overheid.nl/BWBR0011173, 19 februari 2000) regelt het recht van werknemers om te vragen om aanpassing van de arbeidsduur. Op deze wet is een Ampersand analyse gedaan, om inzicht te krijgen in de wijze van modelleren aan de hand van een klein voorbeeld. Daar waar in deze tekst wordt gerefereerd naar een wetsartikel, zonder de naam van de wet erbij te noemen, wordt de Wet aanpassing arbeidsduur bedoeld.+}
 
 PATTERN Arbeidsduur
 
@@ -10,19 +10,19 @@ werkgever :: Arbeidsrelatie -> Persoon
 PRAGMA "In" "is" "de werkgever"
 MEANING "Elke arbeidsrelatie benoemt expliciet welke (rechts)persoon de rol van werkgever vervult."
 PURPOSE RELATION werkgever
-{+Om de werkgever te kunnen bepalen gaan we ervan uit dat elke arbeidsrelatie precies één werkgever heeft.-}
+{+Om de werkgever te kunnen bepalen gaan we ervan uit dat elke arbeidsrelatie precies één werkgever heeft.+}
 
 werknemer :: Arbeidsrelatie -> Persoon
 PRAGMA "In" "is" "de werknemer"
 MEANING "Elke arbeidsrelatie benoemt expliciet welke persoon de rol van werknemer vervult."
 PURPOSE RELATION werknemer
-{+We gaan ervan uit dat elke arbeidsrelatie precies één werknemer heeft.-}
+{+We gaan ervan uit dat elke arbeidsrelatie precies één werknemer heeft.+}
 
 arbeidsduur :: Arbeidsrelatie -> Arbeidsduur
 PRAGMA "In" "is" "als arbeidsduur afgesproken"
 MEANING "Elke arbeidsrelatie vermeldt de afgesproken arbeidsduur."
 PURPOSE RELATION arbeidsduur REF "Artikel 2 lid 1"
-{+De Wet aanpassing arbeidsduur spreekt van ``de uit zijn arbeidsovereenkomst of publiekrechtelijke aanstelling voortvloeiende arbeidsduur''. Dat impliceert dat er voor elke arbeidsovereenkomst of publiekrechtelijke aanstelling precies één arbeidsduur is. Er zijn ongetwijfeld andere wetten en regelingen die dat garanderen, maar hier nemen we dit als een gegeven (uitgangspunt) over.-}
+{+De Wet aanpassing arbeidsduur spreekt van ``de uit zijn arbeidsovereenkomst of publiekrechtelijke aanstelling voortvloeiende arbeidsduur''. Dat impliceert dat er voor elke arbeidsovereenkomst of publiekrechtelijke aanstelling precies één arbeidsduur is. Er zijn ongetwijfeld andere wetten en regelingen die dat garanderen, maar hier nemen we dit als een gegeven (uitgangspunt) over.+}
 
 inDienst :: Arbeidsrelatie -> Datum
 PRAGMA "" "vermeldt" "als tijdstip van indiensttreding"
@@ -53,25 +53,25 @@ ingediend :: Verzoek * Datum [UNI]
 PRAGMA "" "is ingediend"
 MEANING "Van elk verzoek is het tijdstip van indienen geregistreerd."
 PURPOSE RELATION ingediend REF "Artikel 2 lid 3"
-{+Omdat het tijdstip van indienen van het verzoek relevant is voor de ontvankelijkheid ervan, moeten we het registreren.-}
+{+Omdat het tijdstip van indienen van het verzoek relevant is voor de ontvankelijkheid ervan, moeten we het registreren.+}
 
 uitersteBeslisdatum :: Verzoek * Datum [UNI]
 PRAGMA "De beslissing op " " moet uiterlijk " " zijn genomen."
 MEANING "Elk verzoek heeft een uiterste datum waarop de beslissing moet zijn genomen."
 PURPOSE RELATION uitersteBeslisdatum REF "Artikel 2 lid 10"
-{+De wet stelt dat indien de werkgever niet een maand voor het beoogde tijdstip van ingang van de aanpassing op het verzoek heeft beslist, de arbeidsduur wordt aangepast overeenkomstig het verzoek van de werknemer. Om de werkgever te faciliteren om dit soort beslissingen tijdig te nemen, moet voor elk verzoek de uiterste beslisdatum worden geregistreerd.-}
+{+De wet stelt dat indien de werkgever niet een maand voor het beoogde tijdstip van ingang van de aanpassing op het verzoek heeft beslist, de arbeidsduur wordt aangepast overeenkomstig het verzoek van de werknemer. Om de werkgever te faciliteren om dit soort beslissingen tijdig te nemen, moet voor elk verzoek de uiterste beslisdatum worden geregistreerd.+}
 
 isDirecteVoorloperVan :: Verzoek * Verzoek [INJ,UNI,IRF,ASY]
 PRAGMA "" " is het verzoek dat direct is voorafgegaan aan " " aan dezelfde werkgever."
 MEANING "Als ooit een eerder verzoek is gedaan (van een werknemer aan dezelfde werkgever), moet deze bekend zijn." 
 PURPOSE RELATION isDirecteVoorloperVan REF "Artikel 2 lid 3"
-{+Volgens de wet mag een werknemer hoogstens eenmaal per twee jaren, nadat de werkgever op een (eerder) verzoek om aanpassing van de arbeidsduur heeft besloten, opnieuw een verzoek indienen. Daarom moet een opeenvolging van verzoeken van een werknemer bij eenzelfde werkgever worden geregistreerd.-}
+{+Volgens de wet mag een werknemer hoogstens eenmaal per twee jaren, nadat de werkgever op een (eerder) verzoek om aanpassing van de arbeidsduur heeft besloten, opnieuw een verzoek indienen. Daarom moet een opeenvolging van verzoeken van een werknemer bij eenzelfde werkgever worden geregistreerd.+}
 
 laatsteVerzoek :: Arbeidsrelatie * Verzoek [UNI]
 PRAGMA "Het laatste verzoek dat op " " betrekking had, is "
 MEANING "Het laatste verzoek om aanpassing van een arbeidsrelatie moet bekend zijn"
 PURPOSE RELATION laatsteVerzoek REF "Artikel 2 lid 3"
-{+Omdat de wet stelt dat een werknemer hooguit eenmaal per twee jaren om een aanpassing van de arbeidsduur kan verzoeken, moet bekend zijn wat diens laatste verzoek hieromtrent was.-}
+{+Omdat de wet stelt dat een werknemer hooguit eenmaal per twee jaren om een aanpassing van de arbeidsduur kan verzoeken, moet bekend zijn wat diens laatste verzoek hieromtrent was.+}
 
 --[Beslissingen]--
 op :: Beslissing -> Verzoek
@@ -117,31 +117,31 @@ beslisdatum :: Beslissing -> Datum
 PRAGMA "" "is genomen op"
 MEANING "Beslissingen worden genomen op een zekere datum."
 PURPOSE RELATION beslisdatum REF "Artikel 2 lid 3"
-{+Volgens de wet mogen werknemers ten hoogste eenmaal per twee jaren, nadat de werkgever een verzoek om aanpassing van de arbeidsduur heeft ingewilligd of afgewezen, opnieuw een verzoek indienen. Om dit te kunnen toetsen moet de datum waarop beslissingen worden genomen, worden geregistreerd.-}
+{+Volgens de wet mogen werknemers ten hoogste eenmaal per twee jaren, nadat de werkgever een verzoek om aanpassing van de arbeidsduur heeft ingewilligd of afgewezen, opnieuw een verzoek indienen. Om dit te kunnen toetsen moet de datum waarop beslissingen worden genomen, worden geregistreerd.+}
 
 --[Aanpassingen]--
 nieuw :: Aanpassing -> Arbeidsduur
 PRAGMA "" "leidt tot een nieuwe arbeidsduur van"
 MEANING "De arbeidsduur na aanpassing moet in de beslissing worden vermeld."
 PURPOSE RELATION nieuw REF "Artikel 2 lid 3"
-{+De nieuwe arbeidsduur moet eenduidig uit de aanpassing blijken.-}
+{+De nieuwe arbeidsduur moet eenduidig uit de aanpassing blijken.+}
 
 ingang :: Aanpassing -> Datum
 PRAGMA "" "gaat in op"
 MEANING "Het tijdstip van ingang moet in de aanpassing worden vermeld."
 PURPOSE RELATION ingang REF "Artikel 2 lid 3"
-{+De aanpassing van de arbeidsduur moet worden ingediend onder opgave van een beoogd tijdstip van ingang.-}
+{+De aanpassing van de arbeidsduur moet worden ingediend onder opgave van een beoogd tijdstip van ingang.+}
 
 omvang :: Aanpassing -> Omvang
 PRAGMA "" "betreft een verandering ter grootte van"
 MEANING "De omvang van de aanpassing van de arbeidsduur moet worden vermeld."
 PURPOSE RELATION omvang REF "Artikel 2 lid 3"
-{+De aanpassing moet worden ingediend onder opgave van de omvang van de aanpassing van de arbeidsduur per week of, als de arbeidsduur over een ander tijdvak is overeengekomen over dat tijdvak en de gewenste spreiding van de uren over de week of het anderszins overeengekomen tijdvak.-}
+{+De aanpassing moet worden ingediend onder opgave van de omvang van de aanpassing van de arbeidsduur per week of, als de arbeidsduur over een ander tijdvak is overeengekomen over dat tijdvak en de gewenste spreiding van de uren over de week of het anderszins overeengekomen tijdvak.+}
 
 --[Invarianten]--
 
 PURPOSE RULE "Een jaar in dienst" REF "Artikel 2 lid 1"
-{+Omdat werknemers niet direct na indiensttreding een verzoek tot aanpassing mogen doen, geldt in de wet een termijn van een jaar na indiensttreding.-}
+{+Omdat werknemers niet direct na indiensttreding een verzoek tot aanpassing mogen doen, geldt in de wet een termijn van een jaar na indiensttreding.+}
 RULE "Een jaar in dienst" : arbeidsrelatie~;tot;ingang;(I /\ minstensEenJaar~;minstensEenJaar)  |- inDienst;minstensEenJaar
 -- Deze regel geeft alleen overtredingen als 'minstensEenJaar' al is uitgerekend, en laat bovendien toe dat 'TGT I' in onderstaande 'VIOLATION' kan worden gebruikt.
 MEANING "De werknemer, die een verzoek indient, dient ten minste een jaar voorafgaand aan het beoogde tijdstip van ingang van die aanpassing in dienst te zijn bij die werkgever."
@@ -149,7 +149,7 @@ MESSAGE "Wet op Aanpassing van de Arbeidsduur, Artikel 2 lid 1:"
 VIOLATION (SRC werknemer, TXT " is minder dan een jaar voorafgaand aan ingangstijdstip ", TGT I, TXT " in dienst.")
 
 PURPOSE RULE "tijdig indienen" REF "Artikel 2 lid 3"
-{+Omdat werkgevers voldoende tijd moeten krijgen voor het beslissen, schrijft de wet voor dat een aanvraag vier maanden voor de beoogde ingangsdatum van de aanpassing moet worden ingediend.-}
+{+Omdat werkgevers voldoende tijd moeten krijgen voor het beslissen, schrijft de wet voor dat een aanvraag vier maanden voor de beoogde ingangsdatum van de aanpassing moet worden ingediend.+}
 RULE "tijdig indienen" : tot;ingang;vierMaandenOfMeer~ |- ingediend
 MEANING "Deze regel bewaakt dat er minstens vier maanden zijn verstreken tussen het tijdstip van aanvragen en het tijdstip van ingang van de aanpassing."
 MESSAGE "Wet op Aanpassing van de Arbeidsduur, Artikel 2 lid 3"
@@ -159,16 +159,16 @@ RULE "Indieningsmogelijkheden beperken tot 2 jaar":
 minstensTweeJaarTrigger /\ beslisdatum~;op;isDirecteVoorloperVan;(I[Verzoek] /\ laatsteVerzoek~;laatsteVerzoek);ingediend |- minstensTweeJaar
 MEANING "De werknemer kan ten hoogste eenmaal per twee jaren, nadat de werkgever een verzoek om aanpassing van de arbeidsduur heeft ingewilligd of afgewezen, opnieuw een verzoek indienen"
 PURPOSE RULE "Indieningsmogelijkheden beperken tot 2 jaar" REF "Artikel 2 lid 3"
-{+De wet zegt: 'De werknemer kan ten hoogste eenmaal per twee jaren, nadat de werkgever een verzoek om aanpassing van de arbeidsduur heeft ingewilligd of afgewezen, opnieuw een verzoek indienen'. Daarom moet een regel bestaan die dit afdwingt.-}
+{+De wet zegt: 'De werknemer kan ten hoogste eenmaal per twee jaren, nadat de werkgever een verzoek om aanpassing van de arbeidsduur heeft ingewilligd of afgewezen, opnieuw een verzoek indienen'. Daarom moet een regel bestaan die dit afdwingt.+}
 
 RULE "Alleen op het laatste verzoek kan (mogelijk) nog worden besloten": 
 arbeidsrelatie~ /\ -laatsteVerzoek |- arbeidsrelatie~;(I /\ op~;op)
 MEANING "Per arbeidsrelatie mag hoogstens een verzoek bestaan waarover (nog) niet besloten is."
 PURPOSE RULE "Alleen op het laatste verzoek kan (mogelijk) nog worden besloten" REF "Artikel 2 lid 3"
-{+Omdat de wet stelt dat een werknemer hooguit eenmaal per twee jaren om een aanpassing van de arbeidsduur kan verzoeken, kan er op elk tijdstip en per arbeidsrelatie hoogstens een verzoek bestaan waarop nog niet is besloten. Dat is dan dus tevens het laatste verzoek. Deze eigenschap maakt het mogelijk om eenduidig een opeenvolging van verzoeken per arbeidsrelatie te maken.-}
+{+Omdat de wet stelt dat een werknemer hooguit eenmaal per twee jaren om een aanpassing van de arbeidsduur kan verzoeken, kan er op elk tijdstip en per arbeidsrelatie hoogstens een verzoek bestaan waarop nog niet is besloten. Dat is dan dus tevens het laatste verzoek. Deze eigenschap maakt het mogelijk om eenduidig een opeenvolging van verzoeken per arbeidsrelatie te maken.+}
 
 PURPOSE RULE beslisser REF "Artikel 2 lid 1,5,6,7"
-{+Volgens de wet beslist de werkgever over de aanpassing van de arbeidsduur, op basis van een verzoek hiertoe van de werknemer.-}
+{+Volgens de wet beslist de werkgever over de aanpassing van de arbeidsduur, op basis van een verzoek hiertoe van de werknemer.+}
 RULE beslisser : op~;door |- arbeidsrelatie;werkgever
 MEANING "Een beslissing op een verzoek tot aanpassing van een arbeidsrelatie wordt genomen door de werkgever."
 MESSAGE "Artikel 2 lid 1,5,6,7 Wet aanpassing arbeidsduur:"
@@ -181,7 +181,7 @@ PROCESS "Verzoek behandelen"
 
 ROLE Werkgever MAINTAINS "Beslissen over verzoek"
 PURPOSE RULE "Beslissen over verzoek" REF "Artikel 2 lid 10"
-{+De wet stelt dat indien de werkgever niet een maand voor het beoogde tijdstip van ingang van de aanpassing op het verzoek heeft beslist, de arbeidsduur wordt aangepast overeenkomstig het verzoek van de werknemer. Daarom moet op elk verzoek tijdig een besluit worden genomen.-}
+{+De wet stelt dat indien de werkgever niet een maand voor het beoogde tijdstip van ingang van de aanpassing op het verzoek heeft beslist, de arbeidsduur wordt aangepast overeenkomstig het verzoek van de werknemer. Daarom moet op elk verzoek tijdig een besluit worden genomen.+}
 RULE "Beslissen over verzoek" : arbeidsrelatie;werkgever |- op~;door
 MEANING "Degene aan wie een verzoek gericht is dient daarop (tijdig!) een beslissing te nemen."
 MESSAGE "Nog beslissen:"
@@ -189,7 +189,7 @@ VIOLATION (TGT I, TXT " moet voor ", SRC uitersteBeslisdatum, TXT " beslissen ov
 
 ROLE Werkgever MAINTAINS "Beslissing mededelen"
 PURPOSE RULE "Beslissing mededelen" REF "Artikel 2 lid 7"
-{+De beslissing op het verzoek om aanpassing van de arbeidsduur wordt door de werkgever schriftelijk aan de werknemer meegedeeld.-}
+{+De beslissing op het verzoek om aanpassing van de arbeidsduur wordt door de werkgever schriftelijk aan de werknemer meegedeeld.+}
 RULE "Beslissing mededelen" : op |- medegedeeldAan;werknemer~;arbeidsrelatie~ 
 MEANING "De beslissing op een verzoek dient medegedeeld te worden aan de werknemer"
 MESSAGE "Nog te verzenden besluiten:"
@@ -208,10 +208,10 @@ ENDPROCESS
 --[Proces: Rekenen met datums]-----------------------------
 PROCESS "Rekenen met datums"
 PURPOSE PROCESS "Rekenen met datums"
-{+De wet spreekt over tijdsverschillen van minstens vier maanden, of minstens een jaar. Dat vereist het kunnen rekenen met tijden. Omdat Ampersand dat nog niet goed kan, is een proces gedefinieerd dat deze berekeningen uitvoert. Dit proces is hier verder niet gedocumenteerd.-}
+{+De wet spreekt over tijdsverschillen van minstens vier maanden, of minstens een jaar. Dat vereist het kunnen rekenen met tijden. Omdat Ampersand dat nog niet goed kan, is een proces gedefinieerd dat deze berekeningen uitvoert. Dit proces is hier verder niet gedocumenteerd.+}
 
 PURPOSE RULE "Vandaag is 1 (enkele) dag" 
-{+ Om handelingen op een zekere datum uit te kunnen voeren, en omdat we dat in Ampersand moeten kunnen berekenen, voeren we een Concept ``Vandaag'' in (bestaande uit 1 atoom 'VANDAAG').-}
+{+ Om handelingen op een zekere datum uit te kunnen voeren, en omdat we dat in Ampersand moeten kunnen berekenen, voeren we een Concept ``Vandaag'' in (bestaande uit 1 atoom 'VANDAAG').+}
 RULE "Vandaag is 1 (enkele) dag": I[Vandaag] = 'VANDAAG'
 vandaag :: Vandaag * Datum [UNI]
 PRAGMA "" "is de datum"
@@ -222,17 +222,17 @@ RULE "Stel datum van vandaag vast": I[Vandaag] |- vandaag;vandaag~
 VIOLATION (TXT "{EX} SetToday;vandaag;Vandaag;VANDAAG;Datum")
 
 PURPOSE RELATION datumEQV
-{+Omdat een datum op verschillende manieren kan worden genoteerd, en om van deze notatiewijzen de equivalentie vast te kunnen stellen, voeren we de relatie ``datumEQV'' in.-}
+{+Omdat een datum op verschillende manieren kan worden genoteerd, en om van deze notatiewijzen de equivalentie vast te kunnen stellen, voeren we de relatie ``datumEQV'' in.+}
 datumEQV :: Datum * Datum
 MEANING "De relatie 'datumEQV' geeft van elk paar datums weer of ze equivalent zijn, d.w.z. naar dezelfde dag verwijzen."
 
 PURPOSE RELATION datumNEQ
-{+Omdat een datum op verschillende manieren kan worden genoteerd, en om van deze notatiewijzen de niet-equivalentie vast te kunnen stellen, voeren we de relatie ``datumNEQ'' in.-}
+{+Omdat een datum op verschillende manieren kan worden genoteerd, en om van deze notatiewijzen de niet-equivalentie vast te kunnen stellen, voeren we de relatie ``datumNEQ'' in.+}
 datumNEQ :: Datum * Datum
 MEANING "De relatie 'datumNEQ' geeft van elk paar datums weer of ze niet-equivalent zijn, d.w.z. naar verschillende dagen verwijzen."
 
 PURPOSE RELATION datumGD
-{+Om datums te kunnen vergelijken, en omdat we dat in Ampersand moeten kunnen berekenen, voeren we de relatie ``datumGD'' in, d.w.z. de 'groter dan of gelijk aan'-relatie voor datums.-}
+{+Om datums te kunnen vergelijken, en omdat we dat in Ampersand moeten kunnen berekenen, voeren we de relatie ``datumGD'' in, d.w.z. de 'groter dan of gelijk aan'-relatie voor datums.+}
 datumGD :: Datum * Datum
 MEANING "De relatie 'datumGD' geeft van elk paar datums weer welke groter dan of gelijk is aan de ander."
 
@@ -249,7 +249,7 @@ ENDPROCESS
 --[Proces: geautomatiseerde procesondersteuning]-----------
 PROCESS "Geautomatiseerde procesondersteuning"
 PURPOSE PROCESS "Geautomatiseerde procesondersteuning"
-{+Menselijke procesuitvoerders moeten zoveel mogelijk worden ontlast van handelingen die ook geautomatiseerd kunnen worden uitgevoerd. Geautomatiseerde procesondersteuning zorgt ervoor dat informatie die reeds aanwezig is dan wel afleidbaar is uit bestaande informatie, daar waar nodig automatisch wordt ingevuld. Ook zorgt het ervoor dat handelingen automatisch uitgevoerd worden voor zover dit afleidbaar is. Dit hoofdstuk documenteert de afspraken op basis waarvan automatische handelingen worden uitgevoerd.-}
+{+Menselijke procesuitvoerders moeten zoveel mogelijk worden ontlast van handelingen die ook geautomatiseerd kunnen worden uitgevoerd. Geautomatiseerde procesondersteuning zorgt ervoor dat informatie die reeds aanwezig is dan wel afleidbaar is uit bestaande informatie, daar waar nodig automatisch wordt ingevuld. Ook zorgt het ervoor dat handelingen automatisch uitgevoerd worden voor zover dit afleidbaar is. Dit hoofdstuk documenteert de afspraken op basis waarvan automatische handelingen worden uitgevoerd.+}
 
 nieuwVerzoek :: Arbeidsrelatie * Verzoek [UNI]
 ROLE ExecEngine MAINTAINS "Eerste verzoek verwerken"
@@ -275,14 +275,14 @@ arbeidsrelatie;werknemer;(I[Persoon] /\ -(werknemer~;-I[Arbeidsrelatie];werkneme
 MEANING "Als een werknemer die om aanpassing verzoekt slechts 1 arbeidsrelatie heeft, dan wordt deze zo nodig automatisch in het verzoek ingevuld."
 VIOLATION (TXT "{EX} InsPair;arbeidsrelatie;Verzoek;", SRC I, TXT ";Arbeidsrelatie;", TGT I)
 PURPOSE RULE "Arbeidsrelatie invullen (geautomatiseerd)"
-{+ Gebruikers hoeven de arbeidsrelatie in een verzoek niet in te vullen als deze kan worden afgeleid.-}
+{+ Gebruikers hoeven de arbeidsrelatie in een verzoek niet in te vullen als deze kan worden afgeleid.+}
 
 ROLE ExecEngine MAINTAINS "Verzoeksdatum invullen (geautomatiseerd)"
 RULE "Verzoeksdatum invullen (geautomatiseerd)": (I[Verzoek] /\ -(ingediend;ingediend~));V;vandaag |- ingediend
 MEANING "Als de indieningsdatum van een verzoek niet is ingevuld, dan wordt daarvoor automatisch de datum van vandaag ingevuld."
 VIOLATION (TXT "{EX} InsPair;ingediend;Verzoek;", SRC I, TXT ";Datum;", TGT I)
 PURPOSE RULE "Verzoeksdatum invullen (geautomatiseerd)" REF "Artikel 2 lid 3"
-{+Van elk verzoek moet de indieningsdatum bekend zijn, zodat onder meer kan worden gecontroleerd of een werknemer niet teveel verzoeken indient.-}
+{+Van elk verzoek moet de indieningsdatum bekend zijn, zodat onder meer kan worden gecontroleerd of een werknemer niet teveel verzoeken indient.+}
 
 PURPOSE RELATION vierMaandenOfMeer REF "Artikel 2 lid 3"
 {+Omdat de wet een termijn van vier maanden noemt, en omdat we in Ampersand (nog) niet kunnen
@@ -302,10 +302,10 @@ RULE "Uiterste beslisdatum invullen (geautomatiseerd)": (I[Beslissing] /\ -(besl
 MEANING "Als de beslisdatum van een beslissing niet is ingevuld, dan wordt daarvoor automatisch de datum van vandaag ingevuld."
 VIOLATION (TXT "{EX} InsPair;beslisdatum;Beslissing;", SRC I, TXT ";Datum;", TGT I)
 PURPOSE RULE "Uiterste beslisdatum invullen (geautomatiseerd)" REF "Artikel 2 lid 3"
-{+Van elke beslissing moet de beslisdatum bekend zijn, zodat kan worden gecontroleerd of een werknemer niet teveel verzoeken indient.-}
+{+Van elke beslissing moet de beslisdatum bekend zijn, zodat kan worden gecontroleerd of een werknemer niet teveel verzoeken indient.+}
 
 PURPOSE RELATION eenMaandVoordien REF "Artikel 2 lid 10"
-{+Omdat de wet stelt dat een beslissing op een verzoek minimaal 1 maand voorafgaand aan de beoogde ingangsdatum van de aanpassing genomen moet worden, en omdat we dat in Ampersand moeten kunnen berekenen, voeren we een relatie ``eenMaandVoordien'' in.-}
+{+Omdat de wet stelt dat een beslissing op een verzoek minimaal 1 maand voorafgaand aan de beoogde ingangsdatum van de aanpassing genomen moet worden, en omdat we dat in Ampersand moeten kunnen berekenen, voeren we een relatie ``eenMaandVoordien'' in.+}
 eenMaandVoordien :: Datum * Datum [INJ,UNI]
 MEANING "De relatie 'eenMaandVoordien' geeft van elke datum waarvoor dat nodig is, aan welke datum een maand voordien was."
 ROLE ExecEngine MAINTAINS "Bereken een maand voordien"
@@ -323,13 +323,13 @@ MEANING "Van elk verzoek wordt de uiterste belisdatum automatisch vastgesteld."
 VIOLATION (TXT "{EX} InsPair;uitersteBeslisdatum;Verzoek;", SRC I, TXT ";Datum;", TGT I)
 
 PURPOSE RELATION minstensEenJaar REF "Artikel 2 lid 1"
-{+Omdat de wet de voorwaarde stelt dat de werknemer die tot aanpassing van zijn arbeidsduur verzoekt, tenminste 1 jaar voor de ingangsdatum van de aanpassing in dienst moet zijn, willen we dat automatisch kunnen uitrekenen. Daarom voeren we een relatie ``minstensEenJaar'' in.-}
+{+Omdat de wet de voorwaarde stelt dat de werknemer die tot aanpassing van zijn arbeidsduur verzoekt, tenminste 1 jaar voor de ingangsdatum van de aanpassing in dienst moet zijn, willen we dat automatisch kunnen uitrekenen. Daarom voeren we een relatie ``minstensEenJaar'' in.+}
 minstensEenJaar :: Datum * Datum
 PRAGMA "" "ligt minstens een jaar voor"
 MEANING "De relatie 'minstensEenJaar' geeft weer of er minstens een jaar zijn verstreken tussen twee tijdstippen."
 minstensEenJaarTrigger :: Datum * Datum
 PURPOSE RULE "Berekenen van de termijn van een jaar conform artikel 2 lid 1"
-{+Artikel 2 lid 1 stelt dat voor de berekening van de termijn van een jaar, perioden waarin arbeid wordt verricht en die elkaar opvolgen met een onderbreking van niet meer dan drie maanden, worden samengeteld. Ook stelt dit artikel dat dit geldt als arbeid voor verschillende wergevers wordt verricht die ten aanzien van de verrichte arbeid redelijkerwijs geacht moeten worden elkanders opvolger te zijn. Er is voor gekozen om de bedoelde termijn van een jaar geautomatiseerd te berekenen voor zover deze uit een enkele arbeidsovereenkomst valt af te leiden.-} --! Om geheel aan art 2 lid 1 te voldoen moet dus nog een stukje handmatig proces worden gespecificeerd. !-- 
+{+Artikel 2 lid 1 stelt dat voor de berekening van de termijn van een jaar, perioden waarin arbeid wordt verricht en die elkaar opvolgen met een onderbreking van niet meer dan drie maanden, worden samengeteld. Ook stelt dit artikel dat dit geldt als arbeid voor verschillende wergevers wordt verricht die ten aanzien van de verrichte arbeid redelijkerwijs geacht moeten worden elkanders opvolger te zijn. Er is voor gekozen om de bedoelde termijn van een jaar geautomatiseerd te berekenen voor zover deze uit een enkele arbeidsovereenkomst valt af te leiden.+} --! Om geheel aan art 2 lid 1 te voldoen moet dus nog een stukje handmatig proces worden gespecificeerd. !-- 
 ROLE ExecEngine MAINTAINS "Berekenen van de termijn van een jaar conform artikel 2 lid 1"
 RULE "Berekenen van de termijn van een jaar conform artikel 2 lid 1":
        inDienst~;arbeidsrelatie~;tot;ingang |- minstensEenJaarTrigger
@@ -338,13 +338,13 @@ VIOLATION (TXT "{EX} InsPair;minstensEenJaarTrigger;Datum;", SRC I, TXT ";Datum;
           )
 
 PURPOSE RELATION minstensTweeJaar REF "Artikel 2 lid 3"
-{+Omdat de wet de voorwaarde stelt dat de werknemer die tot aanpassing van zijn arbeidsduur verzoekt, tenminste 2 jaar na een voorafgaand besluit wacht met het indienen van een nieuw verzoek, willen we dat automatisch kunnen uitrekenen. Daarom voeren we een relatie ``minstensTweeJaar'' in.-}
+{+Omdat de wet de voorwaarde stelt dat de werknemer die tot aanpassing van zijn arbeidsduur verzoekt, tenminste 2 jaar na een voorafgaand besluit wacht met het indienen van een nieuw verzoek, willen we dat automatisch kunnen uitrekenen. Daarom voeren we een relatie ``minstensTweeJaar'' in.+}
 minstensTweeJaar :: Datum * Datum
 PRAGMA "" "ligt minstens twee jaar voor "
 MEANING "De relatie 'minstensTweeJaar' geeft weer of er minstens twee jaren zijn verstreken tussen twee tijdstippen."
 minstensTweeJaarTrigger :: Datum * Datum
 PURPOSE RULE "Berekenen van de termijn van twee jaar"
-{+Artikel 2 lid 3 stelt dat een werknemer ten hoogste eenmaal per twee jaren, nadat de werkgever een verzoek om aanpassing van de arbeidsduur heeft ingewilligd of afgewezen, opnieuw een verzoek kan indienen.-}
+{+Artikel 2 lid 3 stelt dat een werknemer ten hoogste eenmaal per twee jaren, nadat de werkgever een verzoek om aanpassing van de arbeidsduur heeft ingewilligd of afgewezen, opnieuw een verzoek kan indienen.+}
 ROLE ExecEngine MAINTAINS "Berekenen van de termijn van twee jaar"
 RULE  "Berekenen van de termijn van twee jaar":
        beslisdatum~;op;isDirecteVoorloperVan~;ingediend |- minstensTweeJaarTrigger
@@ -365,14 +365,14 @@ VIOLATION (TXT "{EX} NewStruct;Beslissing"
                ,TXT ";medegedeeldAan;Beslissing;NULL;Persoon;", SRC laatsteVerzoek~;werknemer
           )
 PURPOSE RULE "Beslissen op een verzoek (geautomatiseerd)" REF "Artikel 2 lid 10"
-{+De wet stelt dat indien de werkgever niet een maand voor het beoogde tijdstip van ingang van de aanpassing op het verzoek heeft beslist, de arbeidsduur wordt aangepast overeenkomstig het verzoek van de werknemer. Een dergelijk besluit kan geautomatiseerd worden genomen en verstuurd.-}
+{+De wet stelt dat indien de werkgever niet een maand voor het beoogde tijdstip van ingang van de aanpassing op het verzoek heeft beslist, de arbeidsduur wordt aangepast overeenkomstig het verzoek van de werknemer. Een dergelijk besluit kan geautomatiseerd worden genomen en verstuurd.+}
 
 ROLE ExecEngine MAINTAINS "Effectueren van beslissingen (geautomatiseerd)"
 RULE "Effectueren van beslissingen (geautomatiseerd)": laatsteVerzoek;op~;aanp;nieuw |- arbeidsduur
 MEANING "Een beslissing tot aanpassing van de arbeidsduur moet worden ge-effectueerd in de arbeidsrelatie."
 VIOLATION (TXT "{EX} InsPair;arbeidsduur;Arbeidsrelatie;", SRC I, TXT ";Arbeidsduur;", TGT I)
 PURPOSE RULE "Effectueren van beslissingen (geautomatiseerd)"
-{+Als door (of namens) de werkgever is besloten omtrent de aanpassing van een arbeidsrelatie, dan moet de arbeidsduur in de betreffende arbeidsrelatie worden aangepast. Dat kan automatisch worden uitgevoerd.-}
+{+Als door (of namens) de werkgever is besloten omtrent de aanpassing van een arbeidsrelatie, dan moet de arbeidsduur in de betreffende arbeidsrelatie worden aangepast. Dat kan automatisch worden uitgevoerd.+}
 
 ENDPROCESS
 
@@ -626,7 +626,7 @@ Deze onduidelijkheid wordt niet verder geanalyseerd, omdat we dan naar andere we
 
 CONCEPT Datum "Een datum is de aanduiding van een dag volgens het formaat dag-maand-jaar (bijvoorbeeld: 1-5-2014)."
 PURPOSE CONCEPT Datum
-{+De wet noemt verschillende termijnen. Om hiermee te kunnen rekenen moet bekend zijn wanneer verzoeken zijn ingediend, wanneer iemand een arbeidsrelatie aanging en dergelijke. Om een punt in de tijd aan te geven gebruiken we het concept Datum (meervoud: datums, om verwarring met 'data' (gegevens) te vermijden).-}
+{+De wet noemt verschillende termijnen. Om hiermee te kunnen rekenen moet bekend zijn wanneer verzoeken zijn ingediend, wanneer iemand een arbeidsrelatie aanging en dergelijke. Om een punt in de tijd aan te geven gebruiken we het concept Datum (meervoud: datums, om verwarring met 'data' (gegevens) te vermijden).+}
 
 --[Populaties]---------------------------------------------
 

--- a/testing/Travis/testcases/Misc/Arbeidsduur.adl
+++ b/testing/Travis/testcases/Misc/Arbeidsduur.adl
@@ -31,7 +31,7 @@ PURPOSE RELATION inDienst REF "Artikel 2 lid 3"
 {+Om een verzoek te mogen indienen dient de werknemer ten minste een jaar voorafgaand aan het beoogde tijdstip van ingang van de aanpassing in dienst te zijn bij de werkgever.
 Daarom moet het tijdstip van indiensttreding bekend zijn.
 Dit wetsartikel bevat nuanceringen ten aanzien van de berekening van het tijdvak. 
-Deze details worden om praktische redenen buiten scope gehouden.-}
+Deze details worden om praktische redenen buiten scope gehouden.+}
 
 --[Verzoeken]--
 arbeidsrelatie :: Verzoek -> Arbeidsrelatie
@@ -40,14 +40,14 @@ MEANING "Het verzoek vermeldt de arbeidsrelatie waarop de aanpassing van toepass
 PURPOSE RELATION arbeidsrelatie
 {+Het verzoek moet duidelijk vermelden welke arbeidsrelatie onderwerp is van het verzoek.
 Dat is immers niet vanzelfsprekend in die gevallen waar een werknemer meerdere arbeidsrelaties over verschillende periodes heeft.
-De onderzochte wet sluit zelfs niet uit dat één werkgever en één werknemer op hetzelfde moment verschillende arbeidsrelaties onderhouden.-}
+De onderzochte wet sluit zelfs niet uit dat één werkgever en één werknemer op hetzelfde moment verschillende arbeidsrelaties onderhouden.+}
 
 tot :: Verzoek * Aanpassing [UNI]
 PRAGMA "" "tot"
 MEANING "Elk verzoek beschrijft de gewenste aanpassing van de uit zijn arbeidsovereenkomst of publiekrechtelijke aanstelling voortvloeiende arbeidsduur."
 PURPOSE RELATION tot[Verzoek*Aanpassing] REF "Artikel 2 lid 1"
 {+Omdat het gaat om verzoeken tot aanpassing van de arbeidsduur, gedaan vanuit de werknemer,
-is het beschrijven van de aanpassing verplicht.-}
+is het beschrijven van de aanpassing verplicht.+}
 
 ingediend :: Verzoek * Datum [UNI]
 PRAGMA "" "is ingediend"
@@ -80,7 +80,7 @@ MEANING "Elke beslissing verwijst naar het verzoek waarop de beslissing genomen 
 PURPOSE RELATION op REF "Artikel 2 lid 7"
 {+Duidelijkheid is nodig over de vraag op welk verzoek een beslissing gevraagd wordt.
 De tekst van de wet rept van ``De beslissing op het verzoek ...''
-Daarom wordt voor elke beslissing bijgehouden op welk verzoek de betreffende beslissing genomen wordt.-}
+Daarom wordt voor elke beslissing bijgehouden op welk verzoek de betreffende beslissing genomen wordt.+}
 
 aanp :: Beslissing -> Aanpassing
 PRAGMA "" "tot"
@@ -88,7 +88,7 @@ MEANING "Een beslissing beschrijft de aanpassing van de uit de betreffende arbei
 PURPOSE RELATION aanp[Beslissing*Aanpassing] REF "Artikel 2 lid 7"
 {+De aanpassing waartoe een werkgever besluit kan afwijken van de aanpassing die door de werknemer is verzocht.
 Daarom wordt aan het besluit nadrukkelijk de aanpassing verbonden die door de werkgever is besloten.
-Onder inwilligen zullen we dan ook verstaan dat de aanpassing waarom verzocht is gelijk is aan de aanpassing die in het besluit is vermeld.-}
+Onder inwilligen zullen we dan ook verstaan dat de aanpassing waarom verzocht is gelijk is aan de aanpassing die in het besluit is vermeld.+}
 
 door :: Beslissing -> Persoon
 PRAGMA "" "door"
@@ -96,14 +96,14 @@ MEANING "Elke beslissing wordt door een (rechts)persoon genomen."
 PURPOSE RELATION door
 {+Het moet duidelijk zijn door welke (rechts)persoon een beslissing genomen is.
 Het optreden van natuurlijke personen als tekenbevoegde voor een rechtspersoon wordt buiten deze wet geregeld en valt dan ook buiten de scope van dit model.
-Hier volstaan we met de juridische entiteit, ofwel de werkgever die de beslissing neemt.-}
+Hier volstaan we met de juridische entiteit, ofwel de werkgever die de beslissing neemt.+}
 
 medegedeeldAan :: Beslissing * Persoon [UNI]
 PRAGMA "" "is medegedeeld aan"
 MEANING "Beslissingen kunnen worden medegedeeld aan personen. Dat gebeurt schriftelijk."
 PURPOSE RELATION medegedeeldAan REF "Artikel 2 lid 7"
 {+De beslissing op het verzoek om aanpassing van de arbeidsduur wordt door de werkgever schriftelijk aan de werknemer meegedeeld.
-Daarom wordt het mededelen vastgelegd.-}
+Daarom wordt het mededelen vastgelegd.+}
 
 reden :: Beslissing * Reden [INJ,SUR]
 PRAGMA "" "wordt gemotiveerd door"
@@ -111,7 +111,7 @@ MEANING "Beslissingen kunnen met redenen worden omkleed."
 PURPOSE RELATION reden REF "Artikel 2 lid 7"
 {+Een beslissing, die afwijkt van de wensen van de werknemer, dient onder schriftelijke opgave van de redenen te worden meegedeeld.
 Hier scheppen we de ruimte om redenen voor de beslissing vast te leggen.
-De eis zelf, namelijk dat er redenen moeten zijn voor een afwijkend besluit, is elders in deze analyse geformuleerd.-}
+De eis zelf, namelijk dat er redenen moeten zijn voor een afwijkend besluit, is elders in deze analyse geformuleerd.+}
 
 beslisdatum :: Beslissing -> Datum
 PRAGMA "" "is genomen op"
@@ -197,7 +197,7 @@ VIOLATION (TXT "verzoek van ", SRC op;arbeidsrelatie;werknemer, TXT ", die op ",
 
 PURPOSE RULE "Verzoek gemotiveerd afwijzen" REF "Artikel 2 lid 7"
 {+Indien de werkgever het verzoek niet inwilligt of de spreiding van de uren vaststelt in afwijking van de wensen van de werknemer, wordt dit onder schriftelijke opgave van de redenen meegedeeld.
-Hieruit valt op te maken dat elke afwijkende arbeidsduur vraagt om opgave van redenen.-}
+Hieruit valt op te maken dat elke afwijkende arbeidsduur vraagt om opgave van redenen.+}
 RULE "Verzoek gemotiveerd afwijzen" : I /\ op;tot;-I;aanp~ |- reden;reden~
 MEANING "Wanneer de arbeidsduur uit de beslissing afwijkt van de arbeidsduur uit het verzoek, dan dient er een reden voor te zijn, die in de beslissing wordt opgenomen."
 MESSAGE "Artikel 2 lid 7 Wet aanpassing arbeidsduur eist dat als de besloten arbeidsduur afwijkt van hetgeen is verzocht, dit met (schriftelijke) redenen omkleed moet zijn."
@@ -286,7 +286,7 @@ PURPOSE RULE "Verzoeksdatum invullen (geautomatiseerd)" REF "Artikel 2 lid 3"
 
 PURPOSE RELATION vierMaandenOfMeer REF "Artikel 2 lid 3"
 {+Omdat de wet een termijn van vier maanden noemt, en omdat we in Ampersand (nog) niet kunnen
-rekenen, voeren we een relatie “vierMaandenOfMeer” in. Deze dient als stub voor het rekenwerk.-}
+rekenen, voeren we een relatie “vierMaandenOfMeer” in. Deze dient als stub voor het rekenwerk.+}
 vierMaandenOfMeer :: Datum * Datum
 PRAGMA "" "ligt minstens vier maanden voor"
 MEANING "De relatie 'vierMaandenOfMeer' bevat alleen paren van datums waarvan de eerste minstens vier maanden voor de tweede valt."
@@ -580,34 +580,34 @@ BOX[ "unieke naam" : I
 CONCEPT Verzoek  "Een verzoek is een schrijven waarin een werknemer verzoekt om de arbeidsduur van een arbeidsrelatie aan te passen."
 PURPOSE CONCEPT Verzoek
 {+De wet geeft geen definitie van ``verzoek'' en gaat kennelijk uit van de betekenis algemeen gebruikt Nederlands.
-Wel stelt de wet de eis van een schriftelijk verzoek, waardoor het verzoek het karakter van een document krijgt.-}
+Wel stelt de wet de eis van een schriftelijk verzoek, waardoor het verzoek het karakter van een document krijgt.+}
 
 CONCEPT Aanpassing "Een aanpassing is de gebeurtenis waarbij de arbeidsduur van een arbeidsrelatie verandert."
 PURPOSE CONCEPT Aanpassing
 {+Het begrip aanpassing is nodig om de gebeurtenis van het aanpassen te objectiveren.
-Het gaat in deze wet uitsluitend om het aanpassen van de arbeidsduur, die uit een arbeidsrelatie voortvloeit.-}
+Het gaat in deze wet uitsluitend om het aanpassen van de arbeidsduur, die uit een arbeidsrelatie voortvloeit.+}
 
 CONCEPT Persoon "Een persoon is een natuurlijke persoon of een rechtspersoon, naar geldend Nederlands recht."
 PURPOSE CONCEPT Persoon
 {+Er is sprake van werkgever en werknemer, waarbij de werkgever (naar geldend recht) zowel een natuurlijke persoon als een rechtspersoon kan zijn.
-In deze analyse wordt daarvan geabstraheerd, en noemen we alle natuurlijke- en rechtspersonen gewoon ``Persoon''.-}
+In deze analyse wordt daarvan geabstraheerd, en noemen we alle natuurlijke- en rechtspersonen gewoon ``Persoon''.+}
 
 CONCEPT Beslissing "Een beslissing is een schrijven, waarin een werkgever mededeelt wat hij op een in de beslissing vermeld verzoek heeft besloten."
 PURPOSE CONCEPT Beslissing
 {+Omdat de beslissing (net als het verzoek) schriftelijk wordt meegedeeld, heeft ook de beslissing een documentair karakter.
 Het onderscheid tussen besluit en beslissing, wat we kennen uit de Algemene Wet Bestuursrecht, wordt hier niet gemaakt.
-Wellicht omdat het hier niet alleen over ambtelijke aanstellingen, maar ook over arbeidsovereenkomsten naar burgerlijk recht gaat.-}
+Wellicht omdat het hier niet alleen over ambtelijke aanstellingen, maar ook over arbeidsovereenkomsten naar burgerlijk recht gaat.+}
 
 CONCEPT Reden "Een reden is een omschrijving van de grond van een beslissing."
 PURPOSE CONCEPT Reden
 {+Omdat de Wet aanpassing arbeidsduur expliciet om redenen vraagt, is hiervoor een concept nodig.
-De aard van de redenen kan worden gecategoriseerd conform artikel 1 lid 8-9.-}
+De aard van de redenen kan worden gecategoriseerd conform artikel 1 lid 8-9.+}
 
 CONCEPT Arbeidsrelatie "Onder arbeidsrelatie verstaan we een arbeidsovereenkomst naar burgerlijk recht of publiekrechtelijke aanstelling." "Artikel 1 sub a"
 PURPOSE CONCEPT Arbeidsrelatie REF "Artikel 1 sub a"
 {+De wet spreekt van ``arbeidsovereenkomst naar burgerlijk recht of publiekrechtelijke aanstelling''.
 Kennelijk zijn er twee manieren om een arbeidsrelatie te hebben.
-In de onderhavige analyse spreken we van een arbeidsrelatie, maar bedoelen daarmee zoals in dit artikel staat omschreven.-}
+In de onderhavige analyse spreken we van een arbeidsrelatie, maar bedoelen daarmee zoals in dit artikel staat omschreven.+}
 
 CONCEPT Arbeidsduur "Onder arbeidsduur verstaan we een afspraak over de omvang en het tijdstip van ingang van die afspraak."
 PURPOSE CONCEPT Arbeidsduur
@@ -616,13 +616,13 @@ Een beetje curieus is dan ook dat de Wet aanpassing arbeidsduur ``arbeidsduur'' 
 Wel doet deze wet een aantal aannames, zoals: Arbeidsduur heeft een omvang, die je kunt aanpassen (specifiek door te verminderen of vermeerderen).
 Arbeidsduur heeft ook een tijdstip van ingang.
 Deze aannames zijn in het model verwerkt, zonder te kijken naar andere wetten of regelingen die het begrip verder inkleuren.
-De definitie die we hier hanteren voor Arbeidsduur gaat dan ook wat verder dan strikt uit deze wet kan worden opgemaakt (uitzoeken).-}
+De definitie die we hier hanteren voor Arbeidsduur gaat dan ook wat verder dan strikt uit deze wet kan worden opgemaakt (uitzoeken).+}
 
 CONCEPT Omvang "Onder de omvang verstaan we het aantal uren dat een werknemer per periode voor een werkgever arbeid verricht en de verdeling van die uren over de dag/week/periode."
 PURPOSE CONCEPT Omvang
 {+Niet helemaal duidelijk is wat deze wet verstaat onder de omvang van de arbeidsduur.
 Het aantal uren per week (of tijdvak) valt onder de omvang, maar er is ook een vage aanwijzing over de verdeling van die uren over de week.
-Deze onduidelijkheid wordt niet verder geanalyseerd, omdat we dan naar andere wetten en regelingen moeten kijken.-}
+Deze onduidelijkheid wordt niet verder geanalyseerd, omdat we dan naar andere wetten en regelingen moeten kijken.+}
 
 CONCEPT Datum "Een datum is de aanduiding van een dag volgens het formaat dag-maand-jaar (bijvoorbeeld: 1-5-2014)."
 PURPOSE CONCEPT Datum

--- a/testing/Travis/testcases/Misc/Hello.adl
+++ b/testing/Travis/testcases/Misc/Hello.adl
@@ -4,7 +4,7 @@ PURPOSE PATTERN Hello
 {+
 This pattern is a very small, but demonstrative Ampersand script.
 It contains one relation, one rule and three interfaces.
--}
++}
 
 PATTERN Hello
 

--- a/testing/Travis/testcases/Misc/Kernmodel.adl
+++ b/testing/Travis/testcases/Misc/Kernmodel.adl
@@ -75,7 +75,7 @@ PURPOSE INTERFACE Bestuursorgaan
       ]
 
    PURPOSE INTERFACE Mandaatvoorbehouden 
-   {+ Roger Hage en Sebastiaan Hobers -}
+   {+ Roger Hage en Sebastiaan Hobers +}
    INTERFACE Mandaatvoorbehouden (mandaatgever) FOR Bestuurder: I[Mandaat] 
    BOX[ "Mandaat"      : I
       , "Bevoegdheid": mandaatbevoegdheid[Mandaat*Bevoegdheid]
@@ -294,7 +294,7 @@ RELATION departementsleiding[Departement*Functie]
   RULE "Artikel 10:10 Awb" : krachtens;namens |- beslotenDoor
   MEANING "De Awb zegt dat: een krachtens mandaat genomen besluit vermeldt namens welk bestuursorgaan het besluit is genomen. Dat impliceert dat een besluit altijd in naam van een bestuursorgaan wordt genomen"
   PURPOSE RULE "Artikel 10:10 Awb" LATEX REF "Artikel 10:10 Awb"
-{+De Awb zegt dat een krachtens mandaat genomen besluit vermeldt namens welk bestuursorgaan het besluit is genomen. Dat impliceert dat een besluit altijd in naam van een bestuursorgaan wordt genomen. -}
+{+De Awb zegt dat een krachtens mandaat genomen besluit vermeldt namens welk bestuursorgaan het besluit is genomen. Dat impliceert dat een besluit altijd in naam van een bestuursorgaan wordt genomen. +}
 
 
    -- bevoegdheid hernoemd naar mandaatbevoegdheid omdat bevoegdheid al bestaat
@@ -408,14 +408,14 @@ In artikel 10:4 staat dat ingeval er bij wettelijk voorschrift in de mandaatverl
    --- SPEC MandaatVerleningVoorzien ISA Mandaat
    -- Concept MandaatVerleningVoorzien en relatie isA toegevoegd door Henk Boer, 9 mei 2013; werkt nog niet..
    RELATION isa_nietwettelijkmandaat [Mandaat * Mandaat] [SYM, ASY]
-   PURPOSE RELATION isa_nietwettelijkmandaat LATEX REF "Artikel 10:4 lid 2 Awb" {+ Niet wettelijk in mandaatbevoegdheid voorzien -}
+   PURPOSE RELATION isa_nietwettelijkmandaat LATEX REF "Artikel 10:4 lid 2 Awb" {+ Niet wettelijk in mandaatbevoegdheid voorzien +}
 
   -- RULE Uitgewerkt door Chris Haveman en Henk Boer, aangepast op 9 mei 2013 (HB)
   RULE "Artikel 10:4 Awb - gemandateerde" : isa_nietwettelijkmandaat;gemandateerde /\ mandaatgever;-onder~ |- instemming~
   MEANING "Indien de gemandateerde niet werkzaam is onder verantwoordelijkheid van de mandaatgever, behoeft de mandaatverlening de instemming van de gemandateerde, tenzij wettelijk in de bevoegdheid tot mandaatverlening is voorzien"
 
   PURPOSE RULE "Artikel 10:4 Awb - gemandateerde" LATEX REF "Artikel 10:4 Awb"
-  {+ Het Awb stelt dat instemming vereist is als de gemandateerde niet onder de verantwoordelijkheid valt van het bestuursorgaan, tenzij wettelijk in de bevoegdheid tot mandaatverlening is voorzien -}
+  {+ Het Awb stelt dat instemming vereist is als de gemandateerde niet onder de verantwoordelijkheid valt van het bestuursorgaan, tenzij wettelijk in de bevoegdheid tot mandaatverlening is voorzien +}
 
   -- RULE Toegevoegd door Chris Haveman en Henk Boer, 02-05-2013.
   RULE "Artikel 10:4 Awb - verantwoordelijke" : (isa_nietwettelijkmandaat;gemandateerde /\ mandaatgever;-onder~);onder |- instemming~
@@ -464,7 +464,7 @@ CONCEPT MandaatIntrekkingWijze "Een Mandaatintrekkingwijze is een wijze waarop m
 
 RELATION mandaatTyperen [Mandaat * MandaatType]
 PRAGMA "" " is van mandaattype "
-PURPOSE RELATION mandaatTyperen [Mandaat * MandaatType] REF "Artikel 10:8 lid 2 Awb" {+ De Awb spreekt van algemene mandaten. AANNAME: Kennelijk bestaan er verschillende soorten mandaten, en kunnen mandaten worden ingedeeld in mandaattypen. -}
+PURPOSE RELATION mandaatTyperen [Mandaat * MandaatType] REF "Artikel 10:8 lid 2 Awb" {+ De Awb spreekt van algemene mandaten. AANNAME: Kennelijk bestaan er verschillende soorten mandaten, en kunnen mandaten worden ingedeeld in mandaattypen. +}
 POPULATION mandaatTyperen [Mandaat * MandaatType] CONTAINS
      [ ("Mandaat A", "algemeen mandaat")
      ; ("Mandaat B", "specifiek mandaat")
@@ -472,7 +472,7 @@ POPULATION mandaatTyperen [Mandaat * MandaatType] CONTAINS
 
 mandaatIntrekken :: MandaatIntrekking -> Mandaat 
 PRAGMA "" "betreft het intrekken van"
-PURPOSE RELATION mandaatIntrekken [MandaatIntrekking * Mandaat] REF "Artikel 10:8 lid 2 Awb" {+ De Awb spreekt van het intrekken van mandaten. Omdat voor het intrekken bijzondere regels gelden, onderscheiden we een Mandaatintrekking als een afzonderlijk concept. -}
+PURPOSE RELATION mandaatIntrekken [MandaatIntrekking * Mandaat] REF "Artikel 10:8 lid 2 Awb" {+ De Awb spreekt van het intrekken van mandaten. Omdat voor het intrekken bijzondere regels gelden, onderscheiden we een Mandaatintrekking als een afzonderlijk concept. +}
 POPULATION mandaatIntrekken [MandaatIntrekking * Mandaat] CONTAINS
      [ ("MI00001", "Mandaat A")
      ; ("MI00002", "Mandaat B")
@@ -480,7 +480,7 @@ POPULATION mandaatIntrekken [MandaatIntrekking * Mandaat] CONTAINS
 
 RELATION wijzeMandaatIntrekken [MandaatIntrekking * MandaatIntrekkingWijze]
 PRAGMA "" " geschiedde "
-PURPOSE RELATION wijzeMandaatIntrekken [MandaatIntrekking * MandaatIntrekkingWijze] REF "Artikel 10:8 lid 2 Awb" {+ De Awb spreekt van het het schriftelijk intrekken van mandaten. AANNAME: Kennelijk bestaan er verschillende manieren om een mandaat in te trekken, en is er sprake van zoiets als een mandaatintrekkingwijze. -}
+PURPOSE RELATION wijzeMandaatIntrekken [MandaatIntrekking * MandaatIntrekkingWijze] REF "Artikel 10:8 lid 2 Awb" {+ De Awb spreekt van het het schriftelijk intrekken van mandaten. AANNAME: Kennelijk bestaan er verschillende manieren om een mandaat in te trekken, en is er sprake van zoiets als een mandaatintrekkingwijze. +}
 POPULATION wijzeMandaatIntrekken [MandaatIntrekking * MandaatIntrekkingWijze] CONTAINS
      [ ("MI00001", "schriftelijk")
      ; ("MI00002", "mondeling")
@@ -488,7 +488,7 @@ POPULATION wijzeMandaatIntrekken [MandaatIntrekking * MandaatIntrekkingWijze] CO
 
 RELATION mandaatIntrekkingWijzeToestaan [MandaatType * MandaatIntrekkingWijze]
 PRAGMA "Mandaten van het type " " mogen " " worden ingetrokken."
-PURPOSE RELATION mandaatIntrekkingWijzeToestaan [MandaatType * MandaatIntrekkingWijze] REF "Artikel 10:8 lid 2 Awb" {+ Deze relatie is nodig om te kunnen testen of de regel is overtreden of niet. -}
+PURPOSE RELATION mandaatIntrekkingWijzeToestaan [MandaatType * MandaatIntrekkingWijze] REF "Artikel 10:8 lid 2 Awb" {+ Deze relatie is nodig om te kunnen testen of de regel is overtreden of niet. +}
 POPULATION mandaatIntrekkingWijzeToestaan [MandaatType * MandaatIntrekkingWijze] CONTAINS
      [("algemeen mandaat", "schriftelijk"); ("specifiek mandaat", "schriftelijk"); ("specifiek mandaat", "mondeling")
      ]
@@ -509,13 +509,13 @@ Zo mag bijvoorbeeld een algemeen mandaat alleen schriftelijk worden ingetrokken.
 ENDPATTERN
 
    PURPOSE PROCESS ToevoegenBestuursorganen
-   {+ Toegevoegd op 02-05-20123 door George de Vries en Tim Ruijters -}
+   {+ Toegevoegd op 02-05-20123 door George de Vries en Tim Ruijters +}
    PROCESS ToevoegenBestuursorganen
    ROLE BO MAINTAINS "Artikel 10:2 Awb"
    ENDPROCESS
    --
    PURPOSE INTERFACE Bestuursorganen
-   {+ Toegevoegd op 02-05-20123 door George de Vries en Tim Ruijters -}
+   {+ Toegevoegd op 02-05-20123 door George de Vries en Tim Ruijters +}
    INTERFACE Bestuursorganen (mandaatgever) FOR BO: I[Bestuursorgaan]
    BOX[ "Bestuursorgaan" : I
       , "Mandaat" : namens~

--- a/testing/Travis/testcases/Misc/Kernmodel.adl
+++ b/testing/Travis/testcases/Misc/Kernmodel.adl
@@ -12,7 +12,7 @@ De onderstaande tekst is daarvan een analyse.
 
 Deze analyse is tot stand gekomen als gezamenlijk werkstuk van de cursisten van de ``Masterclass Ampersand 2013''.
 De analyse is dan ook niet compleet en niet getoetst door juridisch deskundigen.
--}
++}
    PURPOSE PATTERN Mandaten
 {+
 Dit hoofdstuk beschrijft de taal zoals die in Afdeling 10:1.1. Awb wordt gebruikt om het mandateren te regelen.
@@ -20,7 +20,7 @@ Waar mogelijk verwijst de tekst naar de bron, zodat de lezer afwijkingen die hij
 Daar waar de tekst afwijkt van de bron is die bron uiteraard meer gezaghebbend dan deze tekst.
 
 Functionele eisen zullen worden opgesteld in de hier gedefinieerde taal.
--}
++}
 
    INTERFACE Overview : I[ONE] {- Stef Joosten, 19 April 2013 -}
    BOX[ "Functies" : V[ONE*Functie]
@@ -33,7 +33,7 @@ Functionele eisen zullen worden opgesteld in de hier gedefinieerde taal.
 
    PURPOSE INTERFACE Functie
    {+ Deze interface is uitsluitend bedoeld als voorbeeld voor de les.
-      Hij is niet geschikt noch bedoeld als interface in de uiteindelijke applicatie... -}
+      Hij is niet geschikt noch bedoeld als interface in de uiteindelijke applicatie... +}
    INTERFACE Functie (formatie, krachtens, beslotenDoor, namens) FOR Bestuurder: I[Functie] {- Stef Joosten, 19 April 2013 -}
    BOX[ "Functie"      : I
       , "Orgaan": formatie~
@@ -55,7 +55,7 @@ Functionele eisen zullen worden opgesteld in de hier gedefinieerde taal.
 
    PURPOSE INTERFACE Mandaat 
    {+ Deze interface is uitsluitend bedoeld als voorbeeld voor de les.
-      Hij is niet geschikt noch bedoeld als interface in de uiteindelijke applicatie... -}
+      Hij is niet geschikt noch bedoeld als interface in de uiteindelijke applicatie... +}
    INTERFACE Mandaat (mandaatgever) FOR Bestuurder: I[Mandaat]  {- Stef Joosten, 19 April 2013 -}
    BOX[ "Mandaat"      : I
       , "Mandaatgever": mandaatgever
@@ -66,7 +66,7 @@ Functionele eisen zullen worden opgesteld in de hier gedefinieerde taal.
       ]
 PURPOSE INTERFACE Bestuursorgaan 
    {+ Deze interface is uitsluitend bedoeld als voorbeeld voor de les.
-      Hij is niet geschikt noch bedoeld als interface in de uiteindelijke applicatie... -}
+      Hij is niet geschikt noch bedoeld als interface in de uiteindelijke applicatie... +}
    INTERFACE Bestuursorgaan (bevoegdheid,formatie) FOR Bestuurder: I[Bestuursorgaan]  {- Henk Boer Chris Haveman, 2 mei 2013 -}
    BOX[ "Bestuursorgaan" : I
       , "Bevoegdheid": bevoegdheid
@@ -100,19 +100,19 @@ PURPOSE INTERFACE Bestuursorgaan
       In deze analyse noemen wij ambtenaren bij functie, zoals ``De directeur-generaal Jeugd en Sanctietoepassing van het Ministerie van Veiligheid en Justitie''.
       De naam van de persoon die deze functie vervult, bijvoorbeeld ``E.M. ten Hoorn Boer'' blijft dan uit zicht.
       In een uitgebreidere versie is het nodig om mandaten aan natuurlijke personen toe te voegen.
-   -}
+   +}
 
    CONCEPT Besluit "Onder besluit wordt verstaan: een schriftelijke beslissing van een bestuursorgaan, inhoudende een publiekrechtelijke rechtshandeling." "Artikel 1:3 lid 1 Awb"
    CONCEPT Beschikking  "Onder beschikking wordt verstaan: een besluit dat niet van algemene strekking is, met inbegrip van de afwijzing van een aanvraag daarvan." "Artikel 1:3 lid 2 Awb"
    PURPOSE CONCEPT Besluit LATEX REF "Artikel 1:3 lid 1 Awb"
 {+
 De wet maakt onderscheid tussen besluiten en beschikkingen. Beide zijn gedefinieerd in de Awb.
--}
++}
 
    PURPOSE RELATION bevoegdheid[Bestuursorgaan*Bevoegdheid] LATEX REF "Artikel 1:3 lid 4 Awb"
 {+In het bestuursrecht wordt een bevoegdheid aan een bepaald bestuursorgaan toegedeeld omdat dit bestuursorgaan het meest geschikt wordt geacht om die taak in overeenstemming met het algemeen belang uit te oefenen. Daarbij spelen niet alleen de positie en de deskundigheid van het betrokken bestuursorgaan een rol, maar ook de mogelijkheid van goede controle op de taakuitvoering. Met het oog daarop worden bestuursbevoegdheden vaak toegekend aan organen die een verantwoordingsplicht hebben jegens een vertegenwoordigend lichaam\footnote{bron: Memorie van Toelichting AwB afd 10.1}.
 De reden van toedeling aan juist deze bestuursorganen is meestal niet zozeer gelegen in het feit dat men verwacht dat zij zelf alle besluiten nemen waartoe de toegekende bevoegdheid de gelegenheid biedt, maar dat men een verantwoordingsplicht van deze organen voor de uitoefening daarvan wenst.
--}
++}
    RELATION bevoegdheid[Bestuursorgaan*Bevoegdheid]
    PRAGMA "" " heeft " " als bevoegdheid"
    MEANING LATEX "De uitspraak ``Bestuursorgaan $b$ heeft $x$ als bevoegdheid.'' behoort tot de gemeenschappelijke taal."
@@ -126,7 +126,7 @@ De reden van toedeling aan juist deze bestuursorganen is meestal niet zozeer gel
 
    PURPOSE RELATION beslotenDoor[Besluit*Bestuursorgaan] LATEX REF "Artikel 1:3 lid 1 Awb"
 {+In de Awb worden beslissingen consequent door bestuursorganen genomen.
--}
++}
    RELATION beslotenDoor[Besluit*Bestuursorgaan]
    PRAGMA "" " is genomen door "
    MEANING LATEX "De uitspraak ``Besluit $b$ is genomen door (bestuursorgaan) $o$.'' behoort tot de gemeenschappelijke taal."
@@ -171,7 +171,7 @@ RELATION departementsleiding[Departement*Functie]
 
    PURPOSE RELATION ondermandaatgever[Mandaatnemer*Functie] LATEX REF "Nota behorende tot de mandaatregeling Bergen 2007"
    {+Er is sprake van ondermandaat als de gemandateerde een aan hem ondergeschikte ambtenaar machtigt om de gemandateerde bevoegdheid uit te oefenen.
-   -}
+   +}
 
 -- RELATION toegevoegd op 02 april door Patrick en Arjan
    RELATION ondermandaatgever[Mandaatnemer*Functie]
@@ -205,10 +205,10 @@ RELATION departementsleiding[Departement*Functie]
 
    PURPOSE RULE "Artikel 10:2 Awb" REF "Artikel 10:2 Awb"
 {+
--}
++}
    PURPOSE RELATION namens[Mandaat*Bestuursorgaan] LATEX REF "Artikel 10:10 Awb"
 {+De Awb zegt dat een krachtens mandaat genomen besluit vermeldt namens welk bestuursorgaan het besluit is genomen.
-   -}
+   +}
    RELATION namens[Mandaat*Bestuursorgaan] [UNI,TOT]  -- ontleend aan Artikel 10:10 Awb
    PRAGMA "" " is verleend in naam van "
    MEANING LATEX "De zin ``Mandaat $m$ is verleend in naam van bestuursorgaan $b$.'' behoort tot de gemeenschappelijke taal."
@@ -224,7 +224,7 @@ RELATION departementsleiding[Departement*Functie]
 
    PURPOSE RELATION mandaatverlener[Mandaat*Bestuursorgaan] LATEX REF "Artikel 10:3, 10:5 Awb"
 {+De Awb zegt dat een bestuursorgaan mandaat kan verlenen.
--}
++}
    RELATION mandaatverlener[Mandaat*Bestuursorgaan] [UNI,TOT]  -- ontleend aan Artikel 10:3 en 10:5 Awb
    PRAGMA "" " is verleend door "
    MEANING LATEX "De zin ``Mandaat $m$ is verleend door bestuursorgaan $b$.'' behoort tot de gemeenschappelijke taal."
@@ -240,7 +240,7 @@ RELATION departementsleiding[Departement*Functie]
 
    PURPOSE RELATION mandaatgever[Mandaat*Functie] LATEX REF "Artikelen 10:6-9 Awb"
 {+De Awb spreekt van een mandaatgever: de ambtenaar die (een deel van) zijn bevoegdheden mandateert aan ondergeschikte ambtenaren.
--}
++}
    RELATION mandaatgever[Mandaat*Functie]
    PRAGMA "" " is verleend door "
    MEANING LATEX "De zin ``Mandaat $m$ is verleend door (mandaatgever) $a$.'' behoort tot de gemeenschappelijke taal."
@@ -255,7 +255,7 @@ RELATION departementsleiding[Departement*Functie]
 
    PURPOSE RELATION gemandateerde[Mandaat*Functie] LATEX REF "Artikel 10:2 Awb"
 {+De Awb spreekt van een gemandateerde: de ambtenaar die bevoegdheden krijgt van hogerhand.
--}
++}
    RELATION gemandateerde[Mandaat*Functie]
    PRAGMA "" " is verleend aan "
    MEANING LATEX "De uitspraak ``Mandaat $m$ is verleend aan (gemandateerde) $g$.'' behoort tot de gemeenschappelijke taal."
@@ -269,7 +269,7 @@ RELATION departementsleiding[Departement*Functie]
 
    PURPOSE RELATION instemming[Functie*Mandaat] LATEX REF "Artikel 10:4 Awb"
 {+De Awb spreekt van instemming voor een mandaat van de gemandateerde en van degene onder wiens verantwoordelijkheid hij valt.
--}
++}
    RELATION instemming[Functie*Mandaat]
    PRAGMA "" " heeft ingestemd met "
    MEANING LATEX "De uitspraak ``Functie $f$ heeft ingestemd met(mandaat) $m$.'' behoort tot de gemeenschappelijke taal."
@@ -284,7 +284,7 @@ RELATION departementsleiding[Departement*Functie]
 
    PURPOSE RELATION krachtens[Besluit*Mandaat] LATEX REF "Artikel 10:10 Awb"
 {+De Awb gebruikt het woord ``krachtens'' om aan te geven dat een besluit is genomen op basis van een een mandaat.
--}
++}
    RELATION krachtens[Besluit*Mandaat]
    PRAGMA "" " is krachtens " " genomen"
    MEANING LATEX "De uitspraak ``Besluit $b$ is krachtens (mandaat) $m$ genomen.'' behoort tot de gemeenschappelijke taal."
@@ -303,7 +303,7 @@ RELATION departementsleiding[Departement*Functie]
 De wetstekst spreekt van ``de gemandateerde bevoegdheid''.
 Kennelijk bestaat er voor elk mandaat een bevoegdheid die gemandateerd wordt.
 In de gemeenschappelijke taal wordt het woordje ``tot'' gebruikt om deze bevoegdheid aan te duiden.
--}
++}
    RELATION mandaatbevoegdheid[Mandaat*Bevoegdheid] [TOT]
    PRAGMA "" " tot "
    MEANING LATEX "De frase ``een mandaat tot $b$'' behoort tot de gemeenschappelijke taal en duidt de bevoegdheid ($b$) aan die wordt gemandateerd."
@@ -319,7 +319,7 @@ In de gemeenschappelijke taal wordt het woordje ``tot'' gebruikt om deze bevoegd
    PURPOSE RELATION beperking[Mandaat*Beperking] LATEX REF "Artikel 10:2 Awb"
 {+De Awb spreekt van ``een door de gemandateerde binnen de grenzen van zijn bevoegdheid genomen besluit''.
 Dit impliceert dat er beperkingen kunnen gelden voor een mandaat.
--}
++}
    RELATION beperking[Mandaat*Beperking]
    PRAGMA "" " geldt ten aanzien van aangelegenheden die " " betreffen"
    MEANING LATEX "De uitspraak ``Mandaat $m$ geldt ten aanzien van aangelegenheden die (beperking) $b$ betreffen.'' behoort tot de gemeenschappelijke taal."
@@ -327,7 +327,7 @@ Dit impliceert dat er beperkingen kunnen gelden voor een mandaat.
    PURPOSE RELATION voorbehouden[Bevoegdheid*Functie] LATEX REF "Artikel 4 Mandaatregeling hoofddirecteur DJI 2013"
 {+De Mandaatregeling hoofddirecteur DJI 2013 spreekt van ``bevoegdheden die voorbehouden blijven aan een bepaalde ambtenaar.''.
 Dit impliceert dat deze bevoegdheden niet kunnen worden ondergemandateerd.
--}
++}
    RELATION voorbehouden[Bevoegdheid*Functie]
    PRAGMA "" " is voorbehouden aan "
    MEANING LATEX "De uitspraak ``Bevoegdheid $b$ s voorbehouden aan (functie) $a$.'' behoort tot de gemeenschappelijke taal."
@@ -335,7 +335,7 @@ Dit impliceert dat deze bevoegdheden niet kunnen worden ondergemandateerd.
    PURPOSE RELATION grond[Bevoegdheid*Titel] LATEX
 {+Bevoegdheden hebben een wettige grondslag.
 Dit betekent dat van elke bevoegdheid de titel kan worden gevonden waar deze bevoegdheid op is gebaseerd.
--}
++}
    RELATION grond[Bevoegdheid*Titel]
    PRAGMA "" " op grond van "
    MEANING LATEX "De frase ``bevoegd op grond van (titel) $t$'' behoort tot de gemeenschappelijke taal en duidt de wettige grondslag aan van de bedoelde bevoegdheid."
@@ -389,7 +389,7 @@ Dit betekent dat van elke bevoegdheid de titel kan worden gevonden waar deze bev
     MEANING "Een ingediend bezwaar krachtens genomen besluit door gemandandateerde of mandaatgever mag niet door de gemandanteerde of mandaatgever zelf besloten worden."
     PURPOSE RULE "Artikel 10:3 lid 3 Awb" LATEX REF "Artikel 10:3 lid 3 Awb"
 {+ Een ingediend bezwaar krachtens genomen besluit door gemandandateerde of mandaatgever mag niet door de gemandanteerde of mandaatgever zelf besloten worden.
--}
++}
 
 
    -- RULE nog uit te werken door George de Vries en Tim Ruijters.
@@ -403,7 +403,7 @@ Dit betekent dat van elke bevoegdheid de titel kan worden gevonden waar deze bev
    PURPOSE CONCEPT MandaatVerleningVoorzien LATEX REF "Artikel 10:4 lid 2 Awb"
 {+
 In artikel 10:4 staat dat ingeval er bij wettelijk voorschrift in de mandaatverlening is voorzien, er geen instemming nodig is. Blijkbaar kan er bij sommige mandaten dit wettelijk voorschrift bestaan.
--}
++}
 
    --- SPEC MandaatVerleningVoorzien ISA Mandaat
    -- Concept MandaatVerleningVoorzien en relatie isA toegevoegd door Henk Boer, 9 mei 2013; werkt nog niet..
@@ -429,7 +429,7 @@ In artikel 10:4 staat dat ingeval er bij wettelijk voorschrift in de mandaatverl
      Daarmee verplicht hij zich overeenkomstig de aanwijzingen van de mandaatgever te handelen
      en staat ook tegenover derden vast dat hij over de gemandateerde bevoegdheid beschikt.
      Dientengevolge zal hij ook niet kunnen weigeren haar uit te oefenen indien dat in de gegeven omstandigheden verlangd kan worden.
-  -}
+  +}
 
    ENDPATTERN
 
@@ -453,7 +453,7 @@ PURPOSE PATTERN "Intrekken van mandaten" LATEX
 {+ Artikel 10:8 lid 2 Awb stelt een beperking in op het intrekken van mandaten:
 Een algemeen mandaat wordt schriftelijk ingetrokken.
 Daartoe moet worden bijgehouden hoe het intrekken van een mandaat is verlopen.
--}
++}
 
 CONCEPT MandaatType "Een mandaattype is een typering van Mandaat." "vrij naar Artikel 10:8 lid 2 Awb"
 
@@ -501,14 +501,14 @@ MEANING "Het intrekken van een mandaat mag alleen geschieden op de toegestane wi
 
 PURPOSE RULE "mandaatIntrekkingWijze" REF "Artikel 10:8 lid 2 Awb"
 {+ Kennelijk bestaan er beperkingen ten aanzien van op welke wijze mandaten ingetrokken mogen worden.
-Zo mag bijvoorbeeld een algemeen mandaat alleen schriftelijk worden ingetrokken.-}
+Zo mag bijvoorbeeld een algemeen mandaat alleen schriftelijk worden ingetrokken.+}
    -- REALTION en POPULATION ingediend[Bezwaarschrift*Besluit] toegevoegd door Roger Hage en Sebastiaan Hobers
    PURPOSE RELATION ingediend[Bezwaarschrift*Besluit] REF "Artikel 3 AwbMandaatregeling"
 {+Tegen een besluit kan een bezwaarschrift worden ingediend.
--}
++}
 ENDPATTERN
 
-   PURPOSE PROCESS ToevoegenBestuursorganen
+   PURPOSE PATTERN ToevoegenBestuursorganen
    {+ Toegevoegd op 02-05-20123 door George de Vries en Tim Ruijters +}
    PROCESS ToevoegenBestuursorganen
    ROLE BO MAINTAINS "Artikel 10:2 Awb"

--- a/testing/Travis/testcases/prototype/ISAtest/Limorange.adl
+++ b/testing/Travis/testcases/prototype/ISAtest/Limorange.adl
@@ -1,5 +1,5 @@
 CONTEXT Limorange IN ENGLISH
-PURPOSE CONTEXT Limorange {+ Simple context for testing edit operations on specilizations -}
+PURPOSE CONTEXT Limorange {+ Simple context for testing edit operations on specilizations +}
 
 CONCEPT Fruit "Most general concept"
 

--- a/testing/Travis/testcases/prototype/shouldFail/try46.adl
+++ b/testing/Travis/testcases/prototype/shouldFail/try46.adl
@@ -6,13 +6,13 @@ s :: A*B
 PATTERN Try46
 RULE ifRthenS : r |- s 
 PURPOSE RULE ifRthenS IN DUTCH 
-{+Dit is de tekst voor de regel ifRthenS. Deze staat in het eerste pattern met de naam Try46.-}
+{+Dit is de tekst voor de regel ifRthenS. Deze staat in het eerste pattern met de naam Try46.+}
 ENDPATTERN
 
 PATTERN Try46
 RULE ifSthenR : s |- r
 PURPOSE RULE ifSthenR IN DUTCH 
-{+Dit is de tekst voor de regel ifSthenR. Deze staat in het tweede pattern met de naam Try46.-}
+{+Dit is de tekst voor de regel ifSthenR. Deze staat in het tweede pattern met de naam Try46.+}
 ENDPATTERN
 
 ENDCONTEXT

--- a/testing/Travis/testcases/prototype/shouldSucceed/CP23xBug1.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/CP23xBug1.adl
@@ -1,6 +1,6 @@
 ﻿CONTEXT CP23xBug1 IN ENGLISH
 PURPOSE CONTEXT CP23xBug1
-{+Here we state the purpose of this context-}
+{+Here we state the purpose of this context+}
 
 INCLUDE "CP23xBug2.adl"
 

--- a/testing/Travis/testcases/prototype/shouldSucceed/CP23xBug2.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/CP23xBug2.adl
@@ -1,5 +1,5 @@
 ﻿CONTEXT CP23xBug2 IN ENGLISH
 PURPOSE CONTEXT CP23xBug2
-{+Here we state the purpose of this context-}
+{+Here we state the purpose of this context+}
 
 ENDCONTEXT

--- a/testing/Travis/testcases/prototype/shouldSucceed/CheckDanglingPurposes.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/CheckDanglingPurposes.adl
@@ -1,26 +1,26 @@
 CONTEXT Purposes IN ENGLISH
 
-PURPOSE CONCEPT   Concpt1    {+Concept purpose: Concpt1-}
-PURPOSE RELATION  rel        {+Relation purpose: rel-}
-PURPOSE RULE      procRule   {+Rule purpose procRule-}
-PURPOSE IDENT     ident      {+Identity purpose: ident-}
-PURPOSE VIEW      view       {+View purpose: view-}
-PURPOSE INTERFACE Iface      {+Interface purpose: IFace-}
-PURPOSE CONTEXT   Purposes   {+Context purpose: Purposes-}
+PURPOSE CONCEPT   Concpt1    {+Concept purpose: Concpt1+}
+PURPOSE RELATION  rel        {+Relation purpose: rel+}
+PURPOSE RULE      procRule   {+Rule purpose procRule+}
+PURPOSE IDENT     ident      {+Identity purpose: ident+}
+PURPOSE VIEW      view       {+View purpose: view+}
+PURPOSE INTERFACE Iface      {+Interface purpose: IFace+}
+PURPOSE CONTEXT   Purposes   {+Context purpose: Purposes+}
 
-PURPOSE PATTERN   Patt       {+Pattern purpose: Patt-}
-PURPOSE CONCEPT   PattConcpt {+Concept purpose: PattConcpt-}
-PURPOSE RELATION  pattRel    {+Relation purpose: pattRel-}
-PURPOSE RULE      pattRule   {+Rule purpose: pattRule-}
-PURPOSE IDENT     pattIdent  {+Identity purpose: pattIdent-}
-PURPOSE VIEW      pattView   {+View purpose: pattView-}
+PURPOSE PATTERN   Patt       {+Pattern purpose: Patt+}
+PURPOSE CONCEPT   PattConcpt {+Concept purpose: PattConcpt+}
+PURPOSE RELATION  pattRel    {+Relation purpose: pattRel+}
+PURPOSE RULE      pattRule   {+Rule purpose: pattRule+}
+PURPOSE IDENT     pattIdent  {+Identity purpose: pattIdent+}
+PURPOSE VIEW      pattView   {+View purpose: pattView+}
 
-PURPOSE PROCESS   Proc       {+Process purpose: Proc-}
-PURPOSE CONCEPT   ProcConcpt {+Concept purpose: ProcConcpt-}
-PURPOSE RELATION  procRel    {+Relation purpose: procRel-}
-PURPOSE RULE      procRule   {+Rule purpose: procRule-}
-PURPOSE IDENT     procIdent  {+Identity purpose: procIdent-}
-PURPOSE VIEW      procView   {+View purpose: procView-}
+PURPOSE PROCESS   Proc       {+Process purpose: Proc+}
+PURPOSE CONCEPT   ProcConcpt {+Concept purpose: ProcConcpt+}
+PURPOSE RELATION  procRel    {+Relation purpose: procRel+}
+PURPOSE RULE      procRule   {+Rule purpose: procRule+}
+PURPOSE IDENT     procIdent  {+Identity purpose: procIdent+}
+PURPOSE VIEW      procView   {+View purpose: procView+}
 
 CONCEPT Concpt1 "{definition of Concpt1}"
 rel :: Concpt1 * Concpt1
@@ -36,7 +36,7 @@ PATTERN Patt
   IDENT pattIdent : PattConcpt(I[PattConcpt])
   VIEW pattView: PattConcpt("":I[PattConcpt])
 
-  PURPOSE CONCEPT Concpt2 {+Concept purpose: Concpt2-} -- test purpose inside pattern
+  PURPOSE CONCEPT Concpt2 {+Concept purpose: Concpt2+} -- test purpose inside pattern
 ENDPATTERN
 
 PROCESS Proc
@@ -46,7 +46,7 @@ PROCESS Proc
   IDENT procIdent : ProcConcpt(I[ProcConcpt])
   VIEW procView: ProcConcpt("":I[ProcConcpt])
 
-  PURPOSE CONCEPT Concpt3 {+Concept purpose: Concpt3-} -- test purpose inside process
+  PURPOSE CONCEPT Concpt3 {+Concept purpose: Concpt3+} -- test purpose inside process
 ENDPROCESS
 
 CONCEPT Concpt2 "{definition of Concpt2}"

--- a/testing/Travis/testcases/prototype/shouldSucceed/EscapeTest.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/EscapeTest.adl
@@ -4,7 +4,7 @@ PURPOSE PATTERN EscapeTest
 {+
 This pattern tests escaping capabilities of the Prototype generator by using 
 special characters on all possible constructs.
--}
++}
 
 -- Special characters that may cause problems:
 

--- a/testing/Travis/testcases/prototype/shouldSucceed/SelectExprTest.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/SelectExprTest.adl
@@ -4,7 +4,7 @@ PURPOSE PATTERN SelectExprTest IN ENGLISH
 {+
 This pattern is meant to test the translation of Expressions in Ampersand into
 SELECT statements in SQL.
--}
++}
 
 PATTERN SelectExprTest
   r :: A*A

--- a/testing/Travis/testcases/prototype/shouldSucceed/SpecEdit.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/SpecEdit.adl
@@ -5,7 +5,7 @@ CONTEXT SpecEdit IN ENGLISH
    Reason: This script was devised to study the behaviour of specialization (CLASSIFY) in a live database.
 -}
 
-PURPOSE CONTEXT SpecEdit {+ Simple context for testing edit operations on narrowed relations -}
+PURPOSE CONTEXT SpecEdit {+ Simple context for testing edit operations on narrowed relations +}
 -- This script contains W-expressions, such as I[Orange];I[Lime];I[Citrus];I[Lemon]. These must be caught by the type checker,
 -- because it is predictable that there can never be any population in a W-expression.
 -- NOTE: these are currently not guaranteed to be empty, as mutual exclusion for CLASSIFY is not enforced (strangeLemon is an example)

--- a/testing/Travis/testcases/prototype/shouldSucceed/Ticket237.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/Ticket237.adl
@@ -14,6 +14,6 @@ PURPOSE CONTEXT Ticket237 MARKDOWN
 {+This script should succeed, because `I[Fruit]-I[Citrus]` must
 be interpreted as  `I[Fruit] /\ (V[Fruit]-I[Citrus])`.
 This is to prove that `I[Fruit]-I[Citrus]` may not be interpreted as `I[Fruit] /\ (V[Citrus]-I[Citrus])`
--}
++}
 
 ENDCONTEXT

--- a/testing/Travis/testcases/prototype/shouldSucceed/Ticket342.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/Ticket342.adl
@@ -7,7 +7,7 @@ PATTERN Percelen
   CONCEPT Perceel "Een geografisch begrensd stuk grond."
 
   PURPOSE RELATION overlapt [Perceel*Perceel] 
-  {+Percelen kunnen overlap vertonen met elkaar. Van overlap tussen twee percelen is sprake als ze zowel geometrisch als in de tijd overlappend zijn.-}
+  {+Percelen kunnen overlap vertonen met elkaar. Van overlap tussen twee percelen is sprake als ze zowel geometrisch als in de tijd overlappend zijn.+}
   overlapt :: Perceel * Perceel PRAGMA "Perceel " " overlapt met perceel "
   MEANING "Een perceel kan overlap hebben met andere percelen."
 POPULATION overlapt [Perceel * Perceel] CONTAINS

--- a/testing/Travis/testcases/prototype/shouldSucceed/Try44.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/Try44.adl
@@ -2,8 +2,8 @@ CONTEXT Try44 IN ENGLISH
 -----------------------------------------------------------
 PATTERN "DocumentationByLanguage"
 
-PURPOSE CONCEPT X IN ENGLISH {+Some english text-}
-PURPOSE CONCEPT X IN DUTCH {+Enige nederlandse woorden-}
+PURPOSE CONCEPT X IN ENGLISH {+Some english text+}
+PURPOSE CONCEPT X IN DUTCH {+Enige nederlandse woorden+}
 
 ENDPATTERN
 -----------------------------------------------------------

--- a/testing/Travis/testcases/prototype/shouldSucceed/Try46.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/Try46.adl
@@ -4,7 +4,7 @@ PURPOSE PATTERN SelectExprTest IN ENGLISH
 {+
 This pattern is meant to test the translation of Expressions in Ampersand into
 SELECT statements in SQL.
--}
++}
 
 PATTERN SelectExprTest
   s :: B*C

--- a/testing/Travis/testcases/prototype/shouldSucceed/residutest.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/residutest.adl
@@ -4,7 +4,7 @@ PURPOSE PATTERN SelectExprTest IN ENGLISH
 {+
 This pattern is meant to test the translation of Expressions in Ampersand into
 SELECT statements in SQL.
--}
++}
 
 PATTERN SelectExprTest
   r :: A*B

--- a/testing/Travis/testcases/prototype/shouldSucceed/specializeTest.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/specializeTest.adl
@@ -29,7 +29,7 @@ I want to introduce a new pair, which has signature [G*G] in the general case.
 However, if the right atom's name is 'Peter', I want that atom to be of type B instead of G.
 At the same time, the left atom must be specialized to A. I.e. I want the left atom to be of type A instead of G.
 This demonstrates that the left atom can be specialized dynamically.
--}
++}
 
 PURPOSE INTERFACE Gs
 {+Here is an experiment you can do.
@@ -37,7 +37,7 @@ PURPOSE INTERFACE Gs
 2. Notice that pair (1,1) is in relation s. This means that 1 has been specialized to A and B by the execengine.
 3. Now insert pair (1,3) into relation r. Study the results and verify that atom 3 is not a B but a G.
 4. Now insert pair (1,3) into relation s. Study the results and verify that atom 3 is both A and B .
--}
++}
 INTERFACE Gs : V[SESSION*G]
 BOX [ name : name
     , r : r


### PR DESCRIPTION
There are actually two changes in this pull request:
1) There no longer is a need to specify the language in your script. 
2) You can now use matching brackets {+ ... +} were markup is used. (This used to be {+ ... -}, which of course is ugly. 