### PR TITLE
Fix preProcessor set and unset flags were reversed

### DIFF
--- a/src/Ampersand/Input/PreProcessor.hs
+++ b/src/Ampersand/Input/PreProcessor.hs
@@ -29,7 +29,7 @@ processFlags :: Set.Set PreProcDefine -- ^ Old set of preprocessor flags
              -> Set.Set PreProcDefine -- ^ Set of preprocessor flags after import
 processFlags oldFlags importList = Set.difference (Set.union oldFlags addedDefines) removedDefines
   where (addedDefines, removedDefines) =
-            (\(added, removed) -> (Set.fromList added, Set.fromList $ map (fromMaybe "" . stripPrefix "!") removed))
+            (\(removed, added) -> (Set.fromList added, Set.fromList $ map (fromMaybe "" . stripPrefix "!") removed))
             (partition (isPrefixOf "!") importList)
 
 -- Shim that changes our 'Either ParseError a' from preProcess' into 'Guarded a'

--- a/testing/Travis/testcases/Preprocessor/Preprocessor.adl
+++ b/testing/Travis/testcases/Preprocessor/Preprocessor.adl
@@ -59,6 +59,6 @@ Files in this project contain examples of the syntax that explain the use.
 
   -- This line should be treated as comment, and not as a --#preprocessor statement.
 
-INCLUDE "./includes/PreprocTest.adl" --# [ "ShowR2", "DoNotShowR1", "EditableInterfaceA", "GenerateErrorIfThisVarIsSet" ] --dit is een test
+INCLUDE "./includes/PreprocTest.adl" --# [ "ShowR2", "DoNotShowR1", "EditableInterfaceA", "GenerateErrorIfThisVarIsSet", "ErrorIfUnset" ] --dit is een test
 
 ENDCONTEXT

--- a/testing/Travis/testcases/Preprocessor/includes/PreprocTest.adl
+++ b/testing/Travis/testcases/Preprocessor/includes/PreprocTest.adl
@@ -29,4 +29,6 @@ INTERFACE "Test": I[SESSION] cRud BOX <SHCOLS>
     ]
   ]
 
+--#IF ErrorIfUnset
 ENDCONTEXT
+--#ENDIF


### PR DESCRIPTION
I did not want to just push to development, hence this temporary branch and PR.

@Michiel-s said something about changing readme.md the last time. I am not exactly sure what is required, and whether that is required here. 

The actual issue should be clear from the commit itself. Commit message is below.

----------------------------------------------------

Setting flags was treated as unsetting flags, and vice-versa.

That is: ```INCLUDE "foo.adl" --# ["FLAG"]``` was treated like
```INCLUDE "foo.adl" --# ["!FLAG"]```. Notably this meant that almost
all scripts were pre-processed as if no flags were set.

The old test did not catch this. This commit modifies the test to fail
if the pre-processor does not read any flags.