### PR TITLE
Improve ignore invariant switch

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,9 +2,10 @@
 
 ## Unreleased changes
 * [Issue #616](https://github.com/AmpersandTarski/Ampersand/issues/616) Add missing TType 'Object' to parser
-
 * [Issue #862](https://github.com/AmpersandTarski/Ampersand/issues/862) Bugfix in generated SQL in several cases where CLASSIFY statements were involved in combination with relations with the INJ property.
 * [Issue #865](https://github.com/AmpersandTarski/Ampersand/issues/865) Another bugfix in the generated SQL
+* Removed --dev switch as alias of self-explanatory --ignore-invariant-violations
+* Improved output of any invariant violations or signals for initial population
 
 ## v3.12.0 (21 december 2018)
 

--- a/src/Ampersand/Components.hs
+++ b/src/Ampersand/Components.hs
@@ -178,7 +178,7 @@ generateAmpersandOutput multi = do
                         ]
                 else False
           reportInvViolations :: [(Rule,AAtomPairs)] -> IO()
-          reportInvViolations []    = verboseLn opts "No invariant violations found for the initial population."
+          reportInvViolations []    = verboseLn opts "No invariant violations found for the initial population"
           reportInvViolations viols =
             if (allowInvariantViolations opts) && not (verboseP opts)
             then
@@ -196,13 +196,18 @@ generateAmpersandOutput multi = do
           showprs aprs = "["++intercalate ", " (Set.elems $ Set.map showA aprs)++"]"
    --       showpr :: AAtomPair -> String
    --       showpr apr = "( "++(showVal.apLeft) apr++", "++(showVal.apRight) apr++" )"
-          reportSignals []        = verboseLn opts "No signals for the initial population."
-          reportSignals conjViols = verboseLn opts $ "Signals for initial population:\n" ++ intercalate "\n"
-            [   "Rule(s): "++(show . map name . Set.elems . rc_orgRules) conj
-            ++"\n  Conjunct   : " ++ showA (rc_conjunct conj)
-            ++"\n  Violations : " ++ showprs viols
-            | (conj, viols) <- conjViols
-            ]
+          reportSignals []        = verboseLn opts "No signals for the initial population"
+          reportSignals conjViols = 
+            if verboseP opts
+            then
+              verboseLn opts $ "Signals for initial population:\n" ++ intercalate "\n"
+                [   "Rule(s): "++(show . map name . Set.elems . rc_orgRules) conj
+                ++"\n  Conjunct   : " ++ showA (rc_conjunct conj)
+                ++"\n  Violations : " ++ showprs viols
+                | (conj, viols) <- conjViols
+                ]
+            else
+              putStrLn "There are signals for the initial population. Use --verbose to output the violations"
           ruleTest :: String -> IO ()
           ruleTest ruleName =
            case [ rule | rule <- Set.elems $ grules fSpec `Set.union` vrules fSpec, name rule == ruleName ] of

--- a/src/Ampersand/Components.hs
+++ b/src/Ampersand/Components.hs
@@ -146,7 +146,7 @@ generateAmpersandOutput multi = do
    doGenProto =
     sequence_ $
        [ verboseLn opts "Checking for rule violations..."
-       , reportViolations violationsOfInvariants
+       , reportInvViolations violationsOfInvariants
        , reportSignals (initialConjunctSignals fSpec)
        ]++
        (if null violationsOfInvariants || allowInvariantViolations opts
@@ -177,9 +177,9 @@ generateAmpersandOutput multi = do
                         , "TOT objExpression[BoxItem*Expression]"
                         ]
                 else False
-          reportViolations :: [(Rule,AAtomPairs)] -> IO()
-          reportViolations []    = verboseLn opts "No violations found."
-          reportViolations viols =
+          reportInvViolations :: [(Rule,AAtomPairs)] -> IO()
+          reportInvViolations []    = verboseLn opts "No invariant violations found for the initial population."
+          reportInvViolations viols =
             if (allowInvariantViolations opts) && not (verboseP opts)
             then
               -- TODO: this is a nice use case for outputting warnings

--- a/src/Ampersand/Components.hs
+++ b/src/Ampersand/Components.hs
@@ -180,8 +180,13 @@ generateAmpersandOutput multi = do
           reportViolations :: [(Rule,AAtomPairs)] -> IO()
           reportViolations []    = verboseLn opts "No violations found."
           reportViolations viols =
-            let ruleNamesAndViolStrings = [ (name r, showprs p) | (r,p) <- viols ]
-            in  putStrLn $ 
+            if (allowInvariantViolations opts) && not (verboseP opts)
+            then
+              -- TODO: this is a nice use case for outputting warnings
+              putStrLn "There are invariant violations that are ignored. Use --verbose to output the violations"
+            else
+              let ruleNamesAndViolStrings = [ (name r, showprs p) | (r,p) <- viols ]
+              in  putStrLn $ 
                          intercalate "\n"
                              [ "Violations of rule "++show r++":\n"++ concatMap (\(_,p) -> "- "++ p ++"\n") rps
                              | rps@((r,_):_) <- groupBy (on (==) fst) $ sort ruleNamesAndViolStrings

--- a/src/Ampersand/Misc/Options.hs
+++ b/src/Ampersand/Misc/Options.hs
@@ -370,7 +370,7 @@ options = [ (Option ['v']   ["version"]
                        ) "config.yaml")
                "config file (*.yaml) that contains the command line options of ampersand."
             , Public)
-          , (Option []      ["dev","ignore-invariant-violations"]
+          , (Option []      ["ignore-invariant-violations"]
                (NoArg (\opts -> opts{allowInvariantViolations = True}))
                "Allow to build a prototype, even if there are invariants that are being violated. (See https://github.com/AmpersandTarski/Ampersand/issues/728)"
             , Hidden)


### PR DESCRIPTION
As discussed today on the phone.

@RieksJ, the terminal output of the invariant rule violations is now suppressed when you use the `--ignore-invariant-violations` switch. Unless of course you request verbosity with `--verbose`.
In return you have to give up the `--dev` alias:)