### PR TITLE
Bugfix #894

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,7 @@
 
 * Hotfix: update to prototype framework v1.1.1. See [releases](https://github.com/AmpersandTarski/Prototype/releases) for more information
 * [Issue #890](https://github.com/AmpersandTarski/Ampersand/issues/890) Add static check for subinterfaces. The target concept of it must be Object, not scalar.
+* [Issue #894](https://github.com/AmpersandTarski/Ampersand/issues/894) Bugfix issue in concepts.json output for prototype
 
 ## v3.13.0 (18 january 2019)
 

--- a/src/Ampersand/Output/ToJSON/Concepts.hs
+++ b/src/Ampersand/Output/ToJSON/Concepts.hs
@@ -63,8 +63,8 @@ instance JSON A_Concept Concept where
   , cptJSONtype              = show . cptTType fSpec $ cpt
   , cptJSONgeneralizations   = map (escapeIdentifier . name) . largerConcepts  (vgens fSpec) $ cpt
   , cptJSONspecializations   = map (escapeIdentifier . name) . smallerConcepts (vgens fSpec) $ cpt
-  , cptJSONdirectGens        = map (escapeIdentifier . name) $ nub [ g | (s,g) <- fsisa fSpec, s == cpt]
-  , cptJSONdirectSpecs       = map (escapeIdentifier . name) $ nub [ s | (s,g) <- fsisa fSpec, g == cpt]
+  , cptJSONdirectGens        = map (escapeIdentifier . name) $ nub [ g | (s,g) <- fsisa fSpec, s == cpt, g /= cpt] -- somehow fsisa contains pairs of (cpt,cpt). These are filtered out with 'g /= cpt'
+  , cptJSONdirectSpecs       = map (escapeIdentifier . name) $ nub [ s | (s,g) <- fsisa fSpec, g == cpt, s /= cpt] -- somehow fsisa contains pairs of (cpt,cpt). There are filtered out with 's /= cpt'
   , cptJSONaffectedConjuncts = map rc_id . fromMaybe [] . lookup cpt . allConjsPerConcept $ fSpec
   , cptJSONinterfaces        = map name . filter hasAsSourceCpt . interfaceS $ fSpec
   , cptJSONdefaultViewId     = fmap name . getDefaultViewForConcept fSpec $ cpt


### PR DESCRIPTION
Fixes #894 

@hanjoosten, I've fixed the issue in the concepts.json output, but I think the real error in further down the chain. As far as I can understand, for each concept A that is part of a classification tree, a pair (A,A) is in `fsisa` of fSpec. I think this is incorrect, but can't see where in the code this is happening. Could you have a look?