### PR TITLE
correcting a mistake in issue #1026

### DIFF
--- a/src/Ampersand/Input/Archi/ArchiAnalyze.hs
+++ b/src/Ampersand/Input/Archi/ArchiAnalyze.hs
@@ -34,7 +34,7 @@ import           Text.XML.HXT.Core hiding (utf8, fatal,trace)
 --   It produces the P_Populations and P_Declarations that represent the Archimate model.
 --   Finally, the function `mkArchiContext` produces a `P_Context` ready to be merged into the rest of Ampersand's population.
 archi2PContext :: (HasLogFunc env) => FilePath -> RIO env (Guarded P_Context)
-archi2PContext archiRepoFilename  -- e.g. "CArepository.xml"
+archi2PContext archiRepoFilename  -- e.g. "CArepository.archimate"
  = do -- hSetEncoding stdout utf8
       archiRepo <- liftIO $ runX (processStraight archiRepoFilename)
       let fst3 (x,_,_) = x

--- a/src/Ampersand/Input/Parsing.hs
+++ b/src/Ampersand/Input/Parsing.hs
@@ -135,7 +135,7 @@ parseSingleADL pc
               popFromExcel <- catchInvalidXlsx $ parseXlsxFile (pcFileKind pc) filePath
               return ((\pops -> (mkContextOfPopsOnly pops,[])) <$> popFromExcel)  -- Excel file cannot contain include files
          | -- This feature enables the parsing of Archimate models in ArchiMate® Model Exchange File Format
-           extension == ".xml" = do 
+           extension == ".archimate" = do 
               ctxFromArchi <- archi2PContext filePath  -- e.g. "CA repository.xml"
               logInfo (display (T.pack filePath) <> " has been interpreted as an Archi-repository.")
               case ctxFromArchi of


### PR DESCRIPTION
Adapt ArchiMate file extension to ".archimate" because it parses Archi-files only (see issue #1026 extended)