### PR TITLE
Archi parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,14 +136,14 @@ install:
 - |
   case "$BUILD" in
     stack)
-      ./travis_long `# guarantee that something is written to output every minute, so travis doesn't stop premature` \
+      ./travis_long `# guarantee that something is written to output every minute, so Travis doesn't stop prematurely` \
            stack build `# build is the common task which is composable.` \
                 --test `# run the tests` \
                 --copy-bins `# install executables to the path` \
-                --haddock `# create haddock documentation, thus ensuring that haddock parse rules are enforsed.` \
-                --no-terminal `# fixes bug with sticky output on travis` \
+                --haddock `# create haddock documentation, thus ensuring that haddock parse rules are enforced.` \
+                --no-terminal `# fixes bug with sticky output on Travis` \
                 $ARGS  `#` \
-                --flag ampersand:buildAll `# build all executables of ampersand`
+                --flag ampersand:buildAll `# build all executables of Ampersand`
       ;;
     cabal)
       cabal --version

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ampersand
 
 [![Build Status](https://travis-ci.org/AmpersandTarski/Ampersand.svg?branch=master)](https://travis-ci.org/AmpersandTarski/Ampersand)
-[![Build status](https://ci.appveyor.com/api/projects/status/ai0pwvb7corwkjjm?svg=true)](https://ci.appveyor.com/project/hanjoosten/ampersand)
+[![Build status](https://ci.appveyor.com/api/projects/status/9stn8mx3w8vsbt2r?svg=true)](https://ci.appveyor.com/project/Ampersand-Sentinel/ampersand)
 [![Latest Release](https://img.shields.io/github/release/AmpersandTarski/Ampersand.svg)](https://github.com/AmpersandTarski/Ampersand/releases/latest)
 
 ## Releases

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [Issue #1026](https://github.com/AmpersandTarski/Ampersand/issues/1026) Allow PATTERNs with the same name. Meaning: all declarations from patterns with the same name are merged into one.
 * [Issue #1081](https://github.com/AmpersandTarski/Ampersand/issues/1081) Disable invariant checking for documentation.
 
 ## v4.0.0 (23 may 2020)

--- a/src/Ampersand/ADL1/P2A_Converters.hs
+++ b/src/Ampersand/ADL1/P2A_Converters.hs
@@ -244,15 +244,15 @@ pCtx2aCtx env
       }
  = do contextInfo <- g_contextInfo -- the minimal amount of data needed to transform things from P-structure to A-structure.
       let declMap = declDisambMap contextInfo
-      uniqueNames p_patterns
+  --  uniqueNames "pattern" p_patterns   -- Unclear why this restriction was in place. So I removed it
       pats        <- traverse (pPat2aPat contextInfo) p_patterns            --  The patterns defined in this context
-      uniqueNames $ p_rules <> concatMap pt_rls p_patterns
+      uniqueNames "rule" $ p_rules <> concatMap pt_rls p_patterns
       rules       <- traverse (pRul2aRul contextInfo Nothing) p_rules       --  All user defined rules in this context, but outside patterns
-      uniqueNames $ p_identdefs <> concatMap pt_ids p_patterns
+      uniqueNames "identity definition" $ p_identdefs <> concatMap pt_ids p_patterns
       identdefs   <- traverse (pIdentity2aIdentity contextInfo Nothing) p_identdefs --  The identity definitions defined in this context, outside the scope of patterns
-      uniqueNames $ p_viewdefs <> concatMap pt_vds p_patterns
+      uniqueNames "view definition" $ p_viewdefs <> concatMap pt_vds p_patterns
       viewdefs    <- traverse (pViewDef2aViewDef contextInfo) p_viewdefs    --  The view definitions defined in this context, outside the scope of patterns
-      uniqueNames p_interfaces
+      uniqueNames "interface" p_interfaces
       interfaces  <- traverse (pIfc2aIfc contextInfo) (p_interfaceAndDisambObjs declMap)   --  TODO: explain   ... The interfaces defined in this context, outside the scope of patterns
       purposes    <- traverse (pPurp2aPurp contextInfo) p_purposes          --  The purposes of objects defined in this context, outside the scope of patterns
       udpops      <- traverse (pPop2aPop contextInfo) p_pops --  [Population]
@@ -710,7 +710,7 @@ pCtx2aCtx env
          P_Box{}
            -> addWarnings warnings $
                        build <$> traverse (join . fmap fn . typecheckObjDef ci) l 
-                             <*  uniqueNames l  -- ensure that each label in a box has a unique name.
+                             <*  uniqueNames "label in box" l  -- ensure that each label in a box has a unique name.
                              <*  mustBeObject (target objExpr)
                   where l :: [P_BoxItem (TermPrim, DisambPrim)]
                         l = si_box x

--- a/src/Ampersand/ADL1/PrettyPrinters.hs
+++ b/src/Ampersand/ADL1/PrettyPrinters.hs
@@ -334,9 +334,7 @@ instance Pretty P_Concept where
     pretty P_ONE = text "ONE"
 
 instance Pretty P_Sign where
-    pretty (P_Sign src tgt) = brackets (pretty src <> maybeTgt)
-        where maybeTgt = if src == tgt then empty
-                         else text "*" <> pretty tgt
+    pretty (P_Sign src tgt) = brackets (pretty src <> text "*" <> pretty tgt)
 
 instance Pretty PClassify where
     pretty p = 

--- a/src/Ampersand/ADL1/PrettyPrinters.hs
+++ b/src/Ampersand/ADL1/PrettyPrinters.hs
@@ -129,7 +129,7 @@ instance Pretty P_Pattern where
           <+\> perline vds
           <+\> perline xps
           <+\> perline pop
-          <+>  text "ENDPATTERN"
+          <+\> text "ENDPATTERN"
 
 instance Pretty P_Relation where
     pretty (P_Sgn nm sign prps pragma mean _) =

--- a/src/Ampersand/Core/ParseTree.hs
+++ b/src/Ampersand/Core/ParseTree.hs
@@ -216,7 +216,7 @@ data P_Relation =
 --   It is easy to see that if the locations are the same, then the relations must be the same.
 --   But is that true all the time? ... No. If one or both origins are unknown, we revert to comparing name and signature.
 --   This is still not true for MEATGRINDER stuff!
-
+--   So,
 -- DO NOT USE ORD and EQ on P_Relation!
 instance Named P_Relation where
  name = dec_nm

--- a/src/Ampersand/Core/ParseTree.hs
+++ b/src/Ampersand/Core/ParseTree.hs
@@ -579,7 +579,7 @@ newtype PMeaning = PMeaning P_Markup
 newtype PMessage = PMessage P_Markup
          deriving Show
 data P_Markup =
-    P_Markup  { mLang   ::   Maybe Lang
+    P_Markup  { mLang   :: Maybe Lang
               , mFormat :: Maybe PandocFormat
               , mString :: Text
               } deriving (Show,Eq) -- for debugging only

--- a/src/Ampersand/FSpec/ToFSpec/CreateFspec.hs
+++ b/src/Ampersand/FSpec/ToFSpec/CreateFspec.hs
@@ -107,9 +107,9 @@ cook :: (HasFSpecGenOpts env) =>
       -> Map MetaModel GrindInfo -- ^ A map containing all GrindInfo that could be required
       -> Guarded P_Context  -- ^ The original user's P_Context, Guarded because it might have errors 
       -> Guarded P_Context 
-cook env (BuildRecipe start steps) grindInfoMap user = 
+cook env (BuildRecipe start steps) grindInfoMap userScript = 
     join $ doSteps <$> case start of
-                    UserScript -> user
+                    UserScript -> userScript
                     MetaScript mm -> pure . pModel $ gInfo mm
   where 
   doSteps :: P_Context -> Guarded P_Context
@@ -120,7 +120,7 @@ cook env (BuildRecipe start steps) grindInfoMap user =
         case step of 
           EncloseInConstraints -> pure $ encloseInConstraints ctx 
           Grind mm -> grind (gInfo mm) <$> (pCtx2Fspec env ctx)
-          MergeWith recipe -> mergeContexts ctx <$> cook env recipe grindInfoMap user
+          MergeWith recipe -> mergeContexts ctx <$> cook env recipe grindInfoMap userScript
   gInfo :: MetaModel -> GrindInfo
   gInfo mm = case Map.lookup mm grindInfoMap of
             Just x -> x

--- a/src/Ampersand/Graphic/Graphics.hs
+++ b/src/Ampersand/Graphic/Graphics.hs
@@ -281,7 +281,7 @@ instance ReferableFromPandoc Picture where
       extention =
          case view fspecFormatL env of
            Fpdf   -> "png"   -- If Pandoc makes a PDF file, the pictures must be delivered in .png format. .pdf-pictures don't seem to work.
-           Fdocx  -> "svg"   -- If Pandoc makes a .docx file, the pictures are delivered in .svg format for scalable rendering in MS-word.
+           Fdocx  -> "png"   -- If Pandoc makes a .docx file, the pictures are delivered in .svg format for scalable rendering in MS-word.
            Fhtml  -> "png"
            _      -> "pdf"
 

--- a/src/Ampersand/Input/Archi/ArchiAnalyze.hs
+++ b/src/Ampersand/Input/Archi/ArchiAnalyze.hs
@@ -62,7 +62,7 @@ archi2PContext archiRepoFilename  -- e.g. "CArepository.archimate"
                          (p_cptnm.pTgt) sig                      <>"\t"<>
                          (tshow.length.eqCl ppRight.p_popps) pop <>"\t"<>
                          (showMaybeInt.elemCount.pTgt) sig
-      logInfo (displayShow archiRepo<>"\n")  -- for debugging
+  --  logInfo (displayShow archiRepo<>"\n")  -- for debugging
       writeFileUtf8 "ArchiCount.txt"
        (T.intercalate "\n" $
            (fmap countPop relPops)

--- a/src/Ampersand/Input/Archi/ArchiAnalyze.hs
+++ b/src/Ampersand/Input/Archi/ArchiAnalyze.hs
@@ -472,7 +472,7 @@ instance MetaArchi Child where
   typeMap _ _
    = Map.empty
   grindArchi env@(Just viewid,typeLookup,maybeViewName) diagrObj
-   = [ translateArlem "inView" (elType,viewtype) maybeViewName (Set.empty) [(chldElem child,viewid)]
+   = [ translateArchiElem "inView" (elType,viewtype) maybeViewName (Set.empty) [(chldElem child,viewid)]
      | child<-childs diagrObj, Just elType<-[typeLookup (chldElem child)], Just viewtype<-[typeLookup viewid]] <>
      [ translateArchiElem "inView" (connType,viewtype) maybeViewName (Set.empty) [(sConRel conn,viewid)]
      | conn<-srcConns diagrObj, Just connType<-[typeLookup (sConRel conn)], Just viewtype<-[typeLookup viewid]] <>

--- a/src/Ampersand/Input/Archi/ArchiAnalyze.hs
+++ b/src/Ampersand/Input/Archi/ArchiAnalyze.hs
@@ -471,7 +471,9 @@ instance MetaArchi Child where
   typeMap _ _
    = Map.empty
   grindArchi env@(Just viewid,typeLookup,maybeViewName) diagrObj
-   = [ translateArchiElem "inView" (connType,viewtype) maybeViewName [(sConRel conn,viewid)]
+   = [ translateArchiElem "inView" (elType,viewtype) maybeViewName [(chldElem child,viewid)]
+     | child<-childs diagrObj, Just elType<-[typeLookup (chldElem child)], Just viewtype<-[typeLookup viewid]] <>
+     [ translateArchiElem "inView" (connType,viewtype) maybeViewName [(sConRel conn,viewid)]
      | conn<-srcConns diagrObj, Just connType<-[typeLookup (sConRel conn)], Just viewtype<-[typeLookup viewid]] <>
      [ translateArchiElem "inside" (childtype,objtype) maybeViewName [(chldElem child,chldElem diagrObj)]
      | child<-childs diagrObj, Just childtype<-[typeLookup (chldElem child)], Just objtype<-[typeLookup (chldElem diagrObj)]] <>

--- a/src/Ampersand/Input/Archi/ArchiAnalyze.hs
+++ b/src/Ampersand/Input/Archi/ArchiAnalyze.hs
@@ -382,13 +382,13 @@ instance MetaArchi ArchiRepo where
   typeMap _ archiRepo
    = typeMap Nothing (archFolders archiRepo)
   grindArchi env archiRepo
-   = [ translateArchiElem "name" ("ArchiRepo","Text") Nothing
+   = [ translateArchiElem "name" ("ArchiRepo","Text") Nothing (Set.singleton Uni)
         [(archRepoId archiRepo, archRepoName archiRepo)]
      ] <>
-     [ translateArchiElem "purpose" ("ArchiRepo","Text") Nothing
+     [ translateArchiElem "purpose" ("ArchiRepo","Text") Nothing (Set.singleton Uni)
         [(archRepoId archiRepo, archPurpVal purp) | purp<-archPurposes archiRepo]
      | (not.null.archPurposes) archiRepo ] <>
-     [ translateArchiElem "propOf" ("Property", "ArchiRepo") Nothing [(propid, archRepoId archiRepo)]
+     [ translateArchiElem "propOf" ("Property", "ArchiRepo") Nothing (Set.singleton Uni) [(propid, archRepoId archiRepo)]
      | prop<-archProperties archiRepo, Just propid<-[archPropId prop]] <>
      (concat . map (grindArchi env)) (archFolders archiRepo)  <> 
      (concat . map (grindArchi env) . archProperties) archiRepo
@@ -413,27 +413,28 @@ instance MetaArchi ArchiObj where
    = Map.fromList [(viewId diagram, "View") | (not.T.null.viewName) diagram] <>
      typeMap (Just (viewName diagram)) (viewProps diagram)
   grindArchi env@(_,_,maybeViewname) element@Element{}
-   = [ translateArchiElem "name" (elemType element,"Text") maybeViewname [(elemId element, elemName element)]
+   = [ translateArchiElem "name" (elemType element,"Text") maybeViewname (Set.singleton Uni) [(elemId element, elemName element)]
      | (not . T.null . elemName) element] <>
-     [ translateArchiElem "docu" (elemType element,"Text") maybeViewname [(elemId element, elemDocu element)] -- documentation in the XML-tag
+     [ translateArchiElem "docu" (elemType element,"Text") maybeViewname (Set.singleton Uni) [(elemId element, elemDocu element)] -- documentation in the XML-tag
      | (not . T.null . elemDocu) element] <>
-     [ translateArchiElem "docu" (elemType element,"Text") maybeViewname [(elemId element, archDocuVal eldo)] -- documentation with <documentation/> tags.
+     [ translateArchiElem "docu" (elemType element,"Text") maybeViewname (Set.singleton Uni) [(elemId element, archDocuVal eldo)] -- documentation with <documentation/> tags.
      | eldo<-elemDocus element] <>
-     [ translateArchiElem "propOf" ("Property", "ArchiObject") maybeViewname [(propid, elemId element)]
+     [ translateArchiElem "propOf" ("Property", "ArchiObject") maybeViewname (Set.singleton Uni) [(propid, elemId element)]
      | prop<-elemProps element, Just propid<-[archPropId prop]] <>
      (concat.map (grindArchi env).elemProps) element
   grindArchi env@(_,typeLookup,maybeViewname) relation@Relationship{}
-   = [ translateArchiElem "name" ("Relationship","Text") maybeViewname [(relId relation, relLabel)]] <>
-     [ translateArchiElem "type" ("Relationship","Text") maybeViewname [(relId relation, relTyp)]] <>
-     [ translateArchiElem "source" ("Relationship",xType) maybeViewname [(relId relation, relSrc relation)]] <>
-     [ translateArchiElem "target" ("Relationship",yType) maybeViewname [(relId relation, relTgt relation)]] <>
-     [ translateArchiElem "docu" ("Relationship","Text") maybeViewname [(relId relation, relDocu relation)] -- documentation in the XML-tag
+   = [ translateArchiElem relLabel (xType,yType) maybeViewname (Set.empty) [(relSrc relation,relTgt relation)]] <>
+     [ translateArchiElem "name" ("Relationship","Text") maybeViewname (Set.singleton Uni) [(relId relation, relLabel)]] <>
+     [ translateArchiElem "type" ("Relationship","Text") maybeViewname (Set.singleton Uni) [(relId relation, relTyp)]] <>
+     [ translateArchiElem "source" ("Relationship",xType) maybeViewname (Set.singleton Uni) [(relId relation, relSrc relation)]] <>
+     [ translateArchiElem "target" ("Relationship",yType) maybeViewname (Set.singleton Uni) [(relId relation, relTgt relation)]] <>
+     [ translateArchiElem "docu" ("Relationship","Text") maybeViewname (Set.singleton Uni) [(relId relation, relDocu relation)] -- documentation in the XML-tag
      | (not . T.null . relDocu) relation] <>
-     [ translateArchiElem "docu" ("Relationship","Text") maybeViewname [(relId relation, archDocuVal reldo)] -- documentation with <documentation/> tags.
+     [ translateArchiElem "docu" ("Relationship","Text") maybeViewname (Set.singleton Uni) [(relId relation, archDocuVal reldo)] -- documentation with <documentation/> tags.
      | reldo<-relDocus relation] <>
-     [ translateArchiElem "accessType" ("Relationship","AccessType") maybeViewname [(relId relation, relAccTp relation)]
+     [ translateArchiElem "accessType" ("Relationship","AccessType") maybeViewname (Set.singleton Uni) [(relId relation, relAccTp relation)]
      | (not . T.null . relAccTp) relation] <>
-     [ translateArchiElem "propOf" ("Property", "Relationship") maybeViewname [(propid, relId relation)]
+     [ translateArchiElem "propOf" ("Property", "Relationship") maybeViewname (Set.singleton Uni) [(propid, relId relation)]
      | prop<-relProps relation, Just propid<-[archPropId prop]] <>
      (concat.map (grindArchi env).relProps) relation
      where
@@ -451,17 +452,17 @@ instance MetaArchi ArchiObj where
                     Just str -> str
                     Nothing -> fatal ("No Archi-object found for Archi-identifier "<>tshow (relTgt relation))
   grindArchi (_, typeLookup,_) diagram@View{}
-   = [ translateArchiElem "name" ("View","Text") maybeViewName [(viewId diagram, viewName diagram)]
+   = [ translateArchiElem "name" ("View","Text") maybeViewName (Set.singleton Uni) [(viewId diagram, viewName diagram)]
      | (not . T.null . viewName) diagram] <>
-     [ translateArchiElem "propOf" ("Property", "View") maybeViewName [(propid, viewId diagram)]
+     [ translateArchiElem "propOf" ("Property", "View") maybeViewName (Set.singleton Uni) [(propid, viewId diagram)]
      | prop<-viewProps diagram, Just propid<-[archPropId prop]] <>
-     [ translateArchiElem "docu" ("View","Text") maybeViewName [(viewId diagram, viewDocu diagram)] -- documentation in the XML-tag
+     [ translateArchiElem "docu" ("View","Text") maybeViewName (Set.singleton Uni) [(viewId diagram, viewDocu diagram)] -- documentation in the XML-tag
      | (not . T.null . viewDocu) diagram] <>
-     [ translateArchiElem "docu" ("View","Text") maybeViewName [(viewId diagram, archDocuVal viewdoc)] -- documentation with <documentation/> tags.
+     [ translateArchiElem "docu" ("View","Text") maybeViewName (Set.singleton Uni) [(viewId diagram, archDocuVal viewdoc)] -- documentation with <documentation/> tags.
      | viewdoc<-viewDocus diagram] <>
-     [ translateArchiElem "inView" (chldType,"View") maybeViewName [(chldElem viewelem, viewId diagram)] -- register the views in which an element is used.
+     [ translateArchiElem "inView" (chldType,"View") maybeViewName (Set.empty) [(chldElem viewelem, viewId diagram)] -- register the views in which an element is used.
      | viewelem<-viewChilds diagram, Just chldType<-[typeLookup (chldElem viewelem)]] <>
-     [ translateArchiElem "viewpoint" ("View","ViewPoint") maybeViewName [(viewId diagram, viewPoint diagram)] -- documentation with <documentation/> tags.
+     [ translateArchiElem "viewpoint" ("View","ViewPoint") maybeViewName (Set.singleton Uni) [(viewId diagram, viewPoint diagram)] -- documentation with <documentation/> tags.
      | (not . T.null . viewPoint) diagram] <>
      (concat . map (grindArchi (Nothing,typeLookup,maybeViewName)) . viewProps) diagram <>
      (concat . map (grindArchi (Just (viewId diagram),typeLookup,maybeViewName)) . viewChilds) diagram
@@ -471,11 +472,11 @@ instance MetaArchi Child where
   typeMap _ _
    = Map.empty
   grindArchi env@(Just viewid,typeLookup,maybeViewName) diagrObj
-   = [ translateArchiElem "inView" (elType,viewtype) maybeViewName [(chldElem child,viewid)]
+   = [ translateArlem "inView" (elType,viewtype) maybeViewName (Set.empty) [(chldElem child,viewid)]
      | child<-childs diagrObj, Just elType<-[typeLookup (chldElem child)], Just viewtype<-[typeLookup viewid]] <>
-     [ translateArchiElem "inView" (connType,viewtype) maybeViewName [(sConRel conn,viewid)]
+     [ translateArchiElem "inView" (connType,viewtype) maybeViewName (Set.empty) [(sConRel conn,viewid)]
      | conn<-srcConns diagrObj, Just connType<-[typeLookup (sConRel conn)], Just viewtype<-[typeLookup viewid]] <>
-     [ translateArchiElem "inside" (childtype,objtype) maybeViewName [(chldElem child,chldElem diagrObj)]
+     [ translateArchiElem "inside" (childtype,objtype) maybeViewName (Set.empty) [(chldElem child,chldElem diagrObj)]
      | child<-childs diagrObj, Just childtype<-[typeLookup (chldElem child)], Just objtype<-[typeLookup (chldElem diagrObj)]] <>
      (concat.map (grindArchi env).childs) diagrObj
   grindArchi (maybeViewid,_,maybeViewName) _ = fatal ("\nmaybeViewid = "<>tshow maybeViewid<>"\nmaybeViewName = "<>tshow maybeViewName)
@@ -484,10 +485,10 @@ instance MetaArchi ArchiProp where
   typeMap _ property
    = Map.fromList [ (propid, "Property") | Just propid<-[archPropId property] ]
   grindArchi (_,_,maybeViewname) property
-   = [ translateArchiElem "key" ("Property","Text") maybeViewname
+   = [ translateArchiElem "key" ("Property","Text") maybeViewname (Set.singleton Uni)
          [(propid, archPropKey property)
          | (not . T.null . archPropKey) property, Just propid<-[archPropId property] ]
-     , translateArchiElem "value" ("Property","Text") maybeViewname
+     , translateArchiElem "value" ("Property","Text") maybeViewname (Set.singleton Uni)
          [(propid, archPropVal property)
          | (not . T.null . archPropVal) property, Just propid<-[archPropId property] ]
      ]
@@ -499,11 +500,11 @@ instance MetaArchi a => MetaArchi [a] where
 -- | The function `translateArchiElem` does the actual compilation of data objects from archiRepo into the Ampersand structure.
 --   It looks redundant to produce both a `P_Population` and a `P_Relation`, but the first contains the population and the second is used to
 --   include the metamodel of ArchiMate in the population. This saves the author the effort of maintaining an ArchiMate-metamodel.
-translateArchiElem :: Text -> (Text, Text) -> Maybe Text -> [(Text, Text)]
+translateArchiElem :: Text -> (Text, Text) -> Maybe Text -> Set.Set Prop-> [(Text, Text)]
                       -> (P_Population,P_Relation,Maybe Text)
-translateArchiElem label (srcLabel,tgtLabel) maybeViewName tuples
+translateArchiElem label (srcLabel,tgtLabel) maybeViewName props tuples
  = ( P_RelPopu Nothing Nothing OriginUnknown (PNamedRel OriginUnknown label (Just (P_Sign (PCpt srcLabel) (PCpt tgtLabel)))) (transTuples tuples)
-   , P_Sgn label (P_Sign (PCpt srcLabel) (PCpt tgtLabel)) (Set.empty) [] [] OriginUnknown
+   , P_Sgn label (P_Sign (PCpt srcLabel) (PCpt tgtLabel)) props [] [] OriginUnknown
    , maybeViewName )
 
 

--- a/src/Ampersand/Input/Archi/ArchiAnalyze.hs
+++ b/src/Ampersand/Input/Archi/ArchiAnalyze.hs
@@ -159,26 +159,26 @@ mkArchiContext [archiRepo] pops = pure
         -- to compute the left-over triples, we must use L.deleteFirstsBy because we do not have Ord P_Population.
         leftovers = L.deleteFirstsBy f pops viewpoprels
          where f (pop,_,_) (pop',_,_) = Set.fromList (p_popps pop)==Set.fromList (p_popps pop')
-        archiPops ::  [P_Population]
-        archiPops = sortRelPops     -- ^ The populations that are local to this pattern
+        archiPops :: [P_Population]
+        archiPops = sortRelPops    --  The populations that are local to this pattern
                      [ pop | (pop,_,_)<-leftovers ]
         archiDecls :: [P_Relation]
-        archiDecls = sortDecls     -- ^ The relations that are declared in this pattern
+        archiDecls = sortDecls     --  The relations that are declared in this pattern
                       [ rel | (_,rel,_)<-leftovers ]
         pats
-         = [ P_Pat { pos =      OriginUnknown     -- ^ the starting position in the file in which this pattern was declared.
-                   , pt_nm =    viewName vw       -- ^ Name of this pattern
-                   , pt_rls =   []                -- ^ The user defined rules in this pattern
-                   , pt_gns =   []                -- ^ The generalizations defined in this pattern
-                   , pt_dcs =   sortDecls rels    -- ^ The relations that are declared in this pattern
-                   , pt_RRuls = []                -- ^ The assignment of roles to rules.
-                   , pt_cds =   []                -- ^ The concept definitions defined in this pattern
-                   , pt_Reprs = []                -- ^ The type into which concepts is represented
-                   , pt_ids =   []                -- ^ The identity definitions defined in this pattern
-                   , pt_vds =   []                -- ^ The view definitions defined in this pattern
-                   , pt_xps =   []                -- ^ The purposes of elements defined in this pattern
-                   , pt_pop =   sortRelPops popus -- ^ The populations that are local to this pattern
-                   , pt_end =   OriginUnknown     -- ^ the end position in the file in which this pattern was declared.
+         = [ P_Pat { pos =      OriginUnknown     -- the starting position in the file in which this pattern was declared.
+                   , pt_nm =    viewName vw       -- Name of this pattern
+                   , pt_rls =   []                -- The user defined rules in this pattern
+                   , pt_gns =   []                -- The generalizations defined in this pattern
+                   , pt_dcs =   sortDecls rels    -- The relations that are declared in this pattern
+                   , pt_RRuls = []                -- The assignment of roles to rules.
+                   , pt_cds =   []                -- The concept definitions defined in this pattern
+                   , pt_Reprs = []                -- The type into which concepts is represented
+                   , pt_ids =   []                -- The identity definitions defined in this pattern
+                   , pt_vds =   []                -- The view definitions defined in this pattern
+                   , pt_xps =   []                -- The purposes of elements defined in this pattern
+                   , pt_pop =   sortRelPops popus -- The populations that are local to this pattern
+                   , pt_end =   OriginUnknown     -- the end position in the file in which this pattern was declared.
                    }
            | folder<-allFolders archiRepo
            , vw@View{}<-fldObjs folder

--- a/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try10.adl
+++ b/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try10.adl
@@ -3,14 +3,14 @@ CONTEXT Try10 IN ENGLISH
 PURPOSE PATTERN Try10 IN ENGLISH 
 {+
 This pattern is meant to test the translation of ObjectDefs in Ampersand.
--}
++}
 
 PATTERN Try10
   r :: A*A
   s :: C*X
   t :: A*B
-  CLASSIFY D ISA A
-  CLASSIFY D ISA C
+  CLASSIFY A ISA D
+  CLASSIFY C ISA D
 ENDPATTERN
 
 INTERFACE Overview : I[ONE]
@@ -29,39 +29,16 @@ INTERFACE Overview : I[ONE]
 ENDCONTEXT
 
 {- 
-   Purpose: to examine the error message deeply inside an interface.
+   Purpose: to check that uniqueness of lables in boxes are tested.
    Result: FAIL
-   Reason: on line 23 there is an error because the source of an attribute (s) does not match with its environment.
+   Reason: on lines 19 and 20 there are duplicate labels.
    
    Message:
-Error(s) found: 
-Type error in BOX 
-Cannot match: 
-- concept "C", Src of : s 
-if you think there is no type error, add an order between the mismatched concepts. 
-Error at symbol () in file /home/sentinel/git/ampersand-models/Tests/ShouldFail/Try10.adl at line 18 : 9 
-============================== 
-Cannot disambiguate: I 
-Please add a signature. 
-You may have intended one of these: 
-I[B] 
-I[C] 
-Error at symbol () in file /home/sentinel/git/ampersand-models/Tests/ShouldFail/Try10.adl at line 22 : 28 
-============================== 
-Type error in BOX 
-Cannot match: 
-- concept "C", Src of : s 
-if you think there is no type error, add an order between the mismatched concepts. 
-Error at symbol () in file /home/sentinel/git/ampersand-models/Tests/ShouldFail/Try10.adl at line 22 : 15 
-============================== 
-Ambiguous type when matching: Tgt of t~ 
-and Src of s. 
-The type can be "C" or "A" 
-None of these concepts is known to be the smallest, you may want to add an order between them. 
-Error at symbol () in file /home/sentinel/git/ampersand-models/Tests/ShouldFail/Try10.adl at line 24 : 30 
-============================== 
-Names / labels must be unique. "r", however, is used at: 
-line 19:15, file /home/sentinel/git/ampersand-models/Tests/ShouldFail/Try10.adl 
-line 20:15, file /home/sentinel/git/ampersand-models/Tests/ShouldFail/Try10.adl. 
-Error at symbol () in file /home/sentinel/git/ampersand-models/Tests/ShouldFail/Try10.adl at line 19 : 15 
+C:> ampersand check Try10.adl
+Reading file /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try10.adl
+/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try10.adl:19:15 error:
+  Every label in box must have a unique name. "r", however, is used at:/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try10.adl:19:15
+      /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try10.adl:20:15.
+ExitFailure 10
+C:>
 -}

--- a/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try11.adl
+++ b/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try11.adl
@@ -1,0 +1,32 @@
+CONTEXT Try11 IN ENGLISH
+
+PURPOSE PATTERN Try11 IN ENGLISH 
+{+
+This pattern is meant to test the translation of Rules in Ampersand.
++}
+
+PATTERN Try11
+  r :: A*A
+  s :: A*A
+  t :: A*A
+ENDPATTERN
+
+RULE "Test Try11" : -(r\/s)
+RULE "Test Try11" : t|-s
+
+ENDCONTEXT
+
+{- 
+   Purpose: to check that uniqueness of RULE names are tested.
+   Result: FAIL
+   Reason: on line 16 and 17 there are two rules with the same name.
+   
+   Message:
+C:> ampersand check Try11.adl
+Reading file /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try11.adl
+/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try11.adl:14:1 error:
+  Every rule must have a unique name. "Test Try11", however, is used at:/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try11.adl:14:1
+      /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try11.adl:15:1.
+ExitFailure 10
+C:>
+-}

--- a/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try13.adl
+++ b/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try13.adl
@@ -1,0 +1,31 @@
+CONTEXT Try13 IN ENGLISH
+
+PURPOSE PATTERN Try13 IN ENGLISH 
+{+
+This pattern is meant to test the translation of Views in Ampersand.
++}
+
+PATTERN Try13
+  r :: A*A
+  s :: A*A
+  t :: A*A
+ENDPATTERN
+
+VIEW Try13: A(TXT "aap",I[A])
+VIEW Try13: A(TXT "noot",r)
+ENDCONTEXT
+
+{- 
+   Purpose: to check that uniqueness of VIEW labels are tested.
+   Result: FAIL
+   Reason: on line 14 and 15 there are two views with the same name.
+   
+   Message:
+C:> ampersand check Try13.adl
+Reading file /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try13.adl
+/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try13.adl:14:1 error:
+  Multiple default views for concept A:VIEW Try13 (at /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try13.adl:14:1)
+      VIEW Try13 (at /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try13.adl:15:1)
+ExitFailure 10
+C:>
+-}

--- a/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try15.adl
+++ b/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try15.adl
@@ -1,0 +1,31 @@
+CONTEXT Try15 IN ENGLISH
+
+PURPOSE PATTERN Try15 IN ENGLISH 
+{+
+This pattern is meant to test the translation of Interfaces in Ampersand.
++}
+
+PATTERN Try15
+  r :: A*A
+  s :: A*A
+  t :: A*A
+ENDPATTERN
+
+INTERFACE "TEST Try15": I[A] cRud BOX [ id : I ]
+INTERFACE "TEST Try15": I[B] cRud BOX [ id : I ]
+ENDCONTEXT
+
+{- 
+   Purpose: to check that uniqueness of INTERFACE labels are tested.
+   Result: FAIL
+   Reason: on line 14 and 15 there are two views with the same name.
+   
+   Message:
+C:> ampersand check Try15.adl
+Reading file /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try15.adl
+/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try15.adl:14:1 error:
+  Every interface must have a unique name. "TEST Try15", however, is used at:/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try15.adl:14:1
+      /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try15.adl:15:1.
+ExitFailure 10
+C:>
+-}

--- a/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try16.adl
+++ b/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try16.adl
@@ -1,0 +1,31 @@
+CONTEXT Try16 IN ENGLISH
+
+PURPOSE PATTERN Try16 IN ENGLISH 
+{+
+This pattern is meant to test the translation of Interfaces in Ampersand.
++}
+
+PATTERN Try16
+  r :: A*A
+  s :: A*A
+  t :: A*A
+ENDPATTERN
+
+INTERFACE "TEST Try16": I[A] cRud BOX [ id : I ]
+INTERFACE "TEST Try16": I[B] cRud BOX [ id : I ]
+ENDCONTEXT
+
+{- 
+   Purpose: to check that uniqueness of INTERFACE labels are tested.
+   Result: FAIL
+   Reason: on line 14 and 15 there are two views with the same name.
+   
+   Message:
+C:> ampersand check Try16.adl
+Reading file /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try16.adl
+/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try16.adl:14:1 error:
+  Every interface must have a unique name. "TEST Try16", however, is used at:/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try16.adl:14:1
+      /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try16.adl:15:1.
+ExitFailure 10
+C:>
+-}

--- a/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try20.adl
+++ b/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try20.adl
@@ -1,0 +1,31 @@
+CONTEXT Try20 IN ENGLISH
+
+PURPOSE PATTERN Try20 IN ENGLISH 
+{+
+This pattern is meant to test the translation of identity definitions in Ampersand.
++}
+
+PATTERN Try20
+  r :: A*A
+  s :: A*A
+  t :: A*A
+ENDPATTERN
+
+IDENT "TEST Try20": A(I)
+IDENT "TEST Try20": B(I)
+ENDCONTEXT
+
+{- 
+   Purpose: to check that uniqueness of IDENT labels are tested.
+   Result: FAIL
+   Reason: on line 14 and 15 there are two identity definitions with the same label.
+   
+   Message:
+C:> ampersand check Try20.adl
+Reading file /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try20.adl
+/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try20.adl:14:1 error:
+  Every identity definition must have a unique name. "TEST Try20", however, is used at:/Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try20.adl:14:1
+      /Users/sjo00577/git/Ampersand/testing/Travis/testcases/prototype/shouldFail/ParserOrTypecheckFailures/Try20.adl:15:1.
+ExitFailure 10
+C:>
+-}

--- a/testing/Travis/testcases/prototype/shouldSucceed/Issue1026.adl
+++ b/testing/Travis/testcases/prototype/shouldSucceed/Issue1026.adl
@@ -1,15 +1,15 @@
-CONTEXT Try46 IN ENGLISH
+CONTEXT Issue1026 IN ENGLISH
 
 r :: A*B
 s :: A*B
 
-PATTERN Try46
+PATTERN SameName
 RULE ifRthenS : r |- s 
 PURPOSE RULE ifRthenS IN DUTCH 
 {+Dit is de tekst voor de regel ifRthenS. Deze staat in het eerste pattern met de naam Try46.+}
 ENDPATTERN
 
-PATTERN Try46
+PATTERN SameName
 RULE ifSthenR : s |- r
 PURPOSE RULE ifSthenR IN DUTCH 
 {+Dit is de tekst voor de regel ifSthenR. Deze staat in het tweede pattern met de naam Try46.+}


### PR DESCRIPTION
I have improved the assembly of ArchiMate Metamodels to include Views as well, to allow for better analysis of architecture models from Archi. For this purpose I have also removed the restriction on PATTERNS to forbid duplicate pattern names. The semantics of a duplicate pattern name is simply the same pattern and I see no reason to forbid that.