### PR TITLE
Use docker hub

### DIFF
--- a/.github/workflows/build-push-to-docker-hub.yml
+++ b/.github/workflows/build-push-to-docker-hub.yml
@@ -7,7 +7,6 @@ on:
     branches: # empty list to trigger all branches
     - master
     - development
-    - use-docker-hub # test this new CI file. TODO: remove this branche here
     tags: # empty list to trigger on all tags
 
 jobs:

--- a/.github/workflows/build-push-to-docker-hub.yml
+++ b/.github/workflows/build-push-to-docker-hub.yml
@@ -1,3 +1,6 @@
+# This workflow builds and pushes Ampersand images to Docker Hub
+# We want to have images for branches 'master' (latest) and 'development' and for all tags (i.e. releases, like e.g. v4.0.2)
+# We use a Github Action from the market place. See: https://github.com/marketplace/actions/build-and-push-docker-images
 name: Build push to Docker Hub
 on:
   push:

--- a/.github/workflows/build-push-to-docker-hub.yml
+++ b/.github/workflows/build-push-to-docker-hub.yml
@@ -22,6 +22,5 @@ jobs:
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}
         repository: ampersandtarski/ampersand
         tag_with_ref: true
-        tag_with_sha: true
         cache_froms: ampersandtarski/ampersand:development
         build_args: GIT_SHA=${{ github.sha }},GIT_Branch=${{ github.ref }}

--- a/.github/workflows/build-push-to-docker-hub.yml
+++ b/.github/workflows/build-push-to-docker-hub.yml
@@ -24,3 +24,4 @@ jobs:
         tag_with_ref: true
         cache_froms: ampersandtarski/ampersand:development
         build_args: GIT_SHA=${{ github.sha }},GIT_Branch=${{ github.ref }}
+        add_git_labels: true

--- a/.github/workflows/build-push-to-docker-hub.yml
+++ b/.github/workflows/build-push-to-docker-hub.yml
@@ -1,0 +1,27 @@
+name: Build push to Docker Hub
+on:
+  push:
+    branches: # empty list to trigger all branches
+    - master
+    - development
+    - use-docker-hub # test this new CI file. TODO: remove this branche here
+    tags: # empty list to trigger on all tags
+
+jobs:
+  build-push:
+    name: Build push
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        repository: ampersandtarski/ampersand
+        tag_with_ref: true
+        tag_with_sha: true
+        cache_froms: ampersandtarski/ampersand:development
+        build_args: GIT_SHA=${{ github.sha }},GIT_Branch=${{ github.ref }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,8 +14,8 @@ jobs:
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables
     # Because steps run in their own process, changes to environment variables are not preserved between steps
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@master # this step reuses a default Github action; see: https://github.com/actions
+    - name: Checkout code
+      uses: actions/checkout@v2
     
     - name: Prepare for docker
       run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,15 +4,13 @@ on:
     branches: # empty list to only trigger on branches (i.e. not tags, ..)
 
 env:
-  DOCKER_AMPERSAND_IMAGE: docker.pkg.github.com/ampersandtarski/ampersand/ampersand
-  DOCKER_AMPERSAND_IMAGE_DEV: docker.pkg.github.com/ampersandtarski/ampersand/ampersand:development
-  # IMAGE_BRANCH_TAG: ${DOCKER_AMPERSAND_IMAGE}:${GITHUB_REF##*/} # Does not work because bash expression is not allowed here
+  DOCKER_AMPERSAND_IMAGE: ampersandtarski/ampersand
+  DOCKER_AMPERSAND_IMAGE_DEV: ampersandtarski/ampersand:development
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    # env:
     
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables
     # Because steps run in their own process, changes to environment variables are not preserved between steps
@@ -24,46 +22,15 @@ jobs:
       run: |
         echo Running on branch ${GITHUB_REF##*/}
         docker version
-        docker login docker.pkg.github.com -u ${GITHUB_ACTOR} -p ${{secrets.GITHUB_TOKEN}}
     
     - name: Pull dev image to use as cache
       run: docker pull ${DOCKER_AMPERSAND_IMAGE_DEV} || true
     
     # This step only builds the 'buildstage' stage (see `--target buildstage`)
+    # See: https://andrewlock.net/caching-docker-layers-on-serverless-build-hosts-with-multi-stage-builds---target,-and---cache-from/ to understand why we use --target and --cache-from here
     - name: Build buildstage
-      run: |
-        # See: https://andrewlock.net/caching-docker-layers-on-serverless-build-hosts-with-multi-stage-builds---target,-and---cache-from/ to understand why we use --target and --cache-from here
-        docker build . --cache-from ${DOCKER_AMPERSAND_IMAGE_DEV} --target buildstage --tag ${DOCKER_AMPERSAND_IMAGE}:${GITHUB_REF##*/} --build-arg GIT_SHA=${{ github.sha }} --build-arg GIT_Branch=${{ github.ref }}
-    
-    # Step disabled because it clutters the package registry on github. Currently public packages cannot be deleted on github.
-    # # This step allows for quicker builds in a future run (see step above where image is pulled to use as cache)
-    # - name: Push buildstage 
-    #   run: docker push ${DOCKER_AMPERSAND_IMAGE}:${GITHUB_REF##*/}
+      run: docker build . --cache-from ${DOCKER_AMPERSAND_IMAGE_DEV} --target buildstage --tag ${DOCKER_AMPERSAND_IMAGE}:${GITHUB_REF##*/} --build-arg GIT_SHA=${{ github.sha }} --build-arg GIT_Branch=${{ github.ref }}
     
     # This step build the final (slim) image 
     - name: Build final image
       run: docker build . --cache-from ${DOCKER_AMPERSAND_IMAGE}:${GITHUB_REF##*/} --tag ${DOCKER_AMPERSAND_IMAGE}:latest --build-arg GIT_SHA=${{ github.sha }} --build-arg GIT_Branch=${{ github.ref }}
-    
-    # Push latest
-    - name: Push ampersand:latest
-      if: github.ref == 'refs/heads/development'
-      run: |
-        docker push ${DOCKER_AMPERSAND_IMAGE_DEV}
-        docker push ${DOCKER_AMPERSAND_IMAGE}:latest
-  
-  # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/persisting-workflow-data-using-artifacts
-  test:
-    name: Test
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-
-  release:
-    name: Release
-    if: github.ref == 'refs/heads/master'
-    needs: [build, test]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo This is only a test
-      

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   DOCKER_AMPERSAND_IMAGE: ampersandtarski/ampersand
-  DOCKER_AMPERSAND_IMAGE_DEV: ampersandtarski/ampersand:development
 
 jobs:
   build:
@@ -23,14 +22,6 @@ jobs:
         echo Running on branch ${GITHUB_REF##*/}
         docker version
     
-    - name: Pull dev image to use as cache
-      run: docker pull ${DOCKER_AMPERSAND_IMAGE_DEV} || true
-    
-    # This step only builds the 'buildstage' stage (see `--target buildstage`)
-    # See: https://andrewlock.net/caching-docker-layers-on-serverless-build-hosts-with-multi-stage-builds---target,-and---cache-from/ to understand why we use --target and --cache-from here
-    - name: Build buildstage
-      run: docker build . --cache-from ${DOCKER_AMPERSAND_IMAGE_DEV} --target buildstage --tag ${DOCKER_AMPERSAND_IMAGE}:${GITHUB_REF##*/} --build-arg GIT_SHA=${{ github.sha }} --build-arg GIT_Branch=${{ github.ref }}
-    
     # This step build the final (slim) image 
     - name: Build final image
-      run: docker build . --cache-from ${DOCKER_AMPERSAND_IMAGE}:${GITHUB_REF##*/} --tag ${DOCKER_AMPERSAND_IMAGE}:latest --build-arg GIT_SHA=${{ github.sha }} --build-arg GIT_Branch=${{ github.ref }}
+      run: docker build . --tag ${DOCKER_AMPERSAND_IMAGE}:latest --build-arg GIT_SHA=${{ github.sha }} --build-arg GIT_Branch=${{ github.ref }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 # The purpose of this docker file is to produce a latest Ampersand-compiler in the form of a docker image.
-# Instruction: If '.' (your working directory) contains this Dockerfile, run "docker build -t docker.pkg.github.com/ampersandtarski/ampersand/ampersand:latest ."
 FROM haskell:8.8 AS buildstage
 
 RUN mkdir /opt/ampersand
@@ -37,11 +36,11 @@ FROM ubuntu
 RUN apt-get update && apt-get install -y graphviz
 
 VOLUME ["/scripts"]
-
-COPY --from=buildstage /root/.local/bin/ampersand /bin/ampersand
-
 WORKDIR /scripts
 
-ENTRYPOINT ["/bin/ampersand"]
+# Copy the Ampersand binary from the build stage to /bin.
+# Note! Other images (i.e. prototype framework) use this image and depend on the binary to be in this location
+COPY --from=buildstage /root/.local/bin/ampersand /bin/ampersand
 
+ENTRYPOINT ["/bin/ampersand"]
 CMD ["--verbose"]

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,7 @@
 ﻿# Release notes of Ampersand
 
 ## Unreleased changes
+* [Issue #1067](https://github.com/AmpersandTarski/Ampersand/issues/1067) Docker build push to Docker hub instead of Github package repo
 * [Issue #1084](https://github.com/AmpersandTarski/Ampersand/issues/1084) Add template attributes to BOX syntax
 * **Breaking change** Because of the implementation of feature of #1084 we could greatly reduce the number of BOX templates (e.g. ROWS, ROWSNL, HROWS and HROWSNL are merged into a single template). Documentation of new templates can be found [here](https://github.com/AmpersandTarski/prototype/tree/master/templates). 
 This breaking change presents the opportunity to rename the built-in templates to more self explaining template names:

--- a/docker/with-texlive/Dockerfile
+++ b/docker/with-texlive/Dockerfile
@@ -2,7 +2,7 @@
 # This Dockerfile is not yet working or tested
 # Contains old setup. Rethinking how to effectively and efficiently textlive can be used by Ampersand compiler
 # !!!!!!!!!!!!!
-FROM docker.pkg.github.com/ampersandtarski/ampersand/ampersand
+FROM ampersandtarski/ampersand:latest
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Fixes #1067 

I've added a CI script to automatically build-push docker images for 'master' and 'development' branch and all tags (i.e. our releases, like v4.0.2, etc).