### PR TITLE
Bug/1045 rename role

### DIFF
--- a/AmpersandData/PrototypeContext/Interfaces.adl
+++ b/AmpersandData/PrototypeContext/Interfaces.adl
@@ -6,23 +6,23 @@ CONTEXT PrototypeFramework IN ENGLISH
     RELATION label[PF_Interface*PF_Label] [UNI,TOT]
         REPRESENT PF_Label TYPE ALPHANUMERIC
 
-    RELATION pf_ifcRoles[PF_Interface*Role]
+    RELATION pf_ifcRoles[PF_Interface*PF_Role]
         MEANING "This relation contains the roles for which an interface is available"
     
     RELATION isPublic[PF_Interface*PF_Interface] [PROP]
         MEANING "This property states that an interface is accessible for all roles (i.e. public)"
 
         -- Cannot enfore this rule yet, because ExecEngine is still required to add missing roles
-        -- RULE "Public interface integrity" : isPublic;V[PF_Interface*Role] |- pf_ifcRoles
+        -- RULE "Public interface integrity" : isPublic;V[PF_Interface*PF_Role] |- pf_ifcRoles
 
-    -- EQUIVALENCE pf_ifcRoles[PF_Interface*Role] == isPublic;V[PF_Interface*Role]
+    -- EQUIVALENCE pf_ifcRoles[PF_Interface*PF_Role] == isPublic;V[PF_Interface*PF_Role]
     ROLE ExecEngine MAINTAINS "Equivalence - InsPair pf_ifcRoles"
-    RULE "Equivalence - InsPair pf_ifcRoles": isPublic;V[PF_Interface*Role] |- pf_ifcRoles
-    VIOLATION (TXT "{EX} InsPair;pf_ifcRoles;PF_Interface;", SRC I, TXT ";Role;", TGT I)
+    RULE "Equivalence - InsPair pf_ifcRoles": isPublic;V[PF_Interface*PF_Role] |- pf_ifcRoles
+    VIOLATION (TXT "{EX} InsPair;pf_ifcRoles;PF_Interface;", SRC I, TXT ";PF_Role;", TGT I)
     
     ROLE ExecEngine MAINTAINS "Equivalence - DelPair pf_ifcRoles"
-    RULE "Equivalence - DelPair pf_ifcRoles": isPublic;pf_ifcRoles |- isPublic;V[PF_Interface*Role]
-    VIOLATION (TXT "{EX} DelPair;pf_ifcRoles;PF_Interface;", SRC I, TXT ";Role;", TGT I)
+    RULE "Equivalence - DelPair pf_ifcRoles": isPublic;pf_ifcRoles |- isPublic;V[PF_Interface*PF_Role]
+    VIOLATION (TXT "{EX} DelPair;pf_ifcRoles;PF_Interface;", SRC I, TXT ";PF_Role;", TGT I)
 
     RELATION isAPI[PF_Interface*PF_Interface] [PROP]
         MEANING "This property states that an interface is meant as API (machine-2-machine)"

--- a/AmpersandData/PrototypeContext/Navbar.adl
+++ b/AmpersandData/PrototypeContext/Navbar.adl
@@ -32,26 +32,26 @@ CONTEXT PrototypeFramework IN ENGLISH
     RELATION isSubItemOf[PF_NavMenuItem*PF_NavMenuItem] [UNI,IRF,ASY]
         MEANING "A navbar item can be a sub item of another item"
 
-    RELATION pf_navItemRoles[PF_NavMenuItem*Role]
+    RELATION pf_navItemRoles[PF_NavMenuItem*PF_Role]
         MEANING "A navbar item is accessible for a role"
 
     -- Add/remove menu items based on interface roles
     ROLE ExecEngine MAINTAINS "Add navItemRoles for interfaces"
     RULE "Add navItemRoles for interfaces" : ifc;pf_ifcRoles |- pf_navItemRoles
-    VIOLATION (TXT "{EX}InsPair;pf_navItemRoles;PF_NavMenuItem;", SRC I, TXT ";Role;", TGT I)
+    VIOLATION (TXT "{EX}InsPair;pf_navItemRoles;PF_NavMenuItem;", SRC I, TXT ";PF_Role;", TGT I)
 
     ROLE ExecEngine MAINTAINS "Remove navItemRoles for interfaces"
     RULE "Remove navItemRoles for interfaces" : (I /\ ifc;ifc~);pf_navItemRoles |- ifc;pf_ifcRoles
-    VIOLATION (TXT "{EX}DelPair;pf_navItemRoles;PF_NavMenuItem;", SRC I, TXT ";Role;", TGT I)
+    VIOLATION (TXT "{EX}DelPair;pf_navItemRoles;PF_NavMenuItem;", SRC I, TXT ";PF_Role;", TGT I)
 
     -- Add/remove parent menu items if needed
     ROLE ExecEngine MAINTAINS "Add navItemRoles for parent items"
     RULE "Add navItemRoles for parent items": isSubItemOf~;pf_navItemRoles |- pf_navItemRoles
-    VIOLATION (TXT "{EX}InsPair;pf_navItemRoles;PF_NavMenuItem;", SRC I, TXT ";Role;", TGT I)
+    VIOLATION (TXT "{EX}InsPair;pf_navItemRoles;PF_NavMenuItem;", SRC I, TXT ";PF_Role;", TGT I)
 
     ROLE ExecEngine MAINTAINS "Remove navItemRoles for parent items"
     RULE "Remove navItemRoles for parent items": (I /\ isSubItemOf~;isSubItemOf);pf_navItemRoles |- isSubItemOf~;pf_navItemRoles
-    VIOLATION (TXT "{EX}DelPair;pf_navItemRoles;PF_NavMenuItem;", SRC I, TXT ";Role;", TGT I)
+    VIOLATION (TXT "{EX}DelPair;pf_navItemRoles;PF_NavMenuItem;", SRC I, TXT ";PF_Role;", TGT I)
     
     --[NAV MENUS]----------------------------------------------------------------------------------
     CONCEPT PF_NavMenu ""

--- a/AmpersandData/PrototypeContext/Navbar.ifc
+++ b/AmpersandData/PrototypeContext/Navbar.ifc
@@ -21,7 +21,7 @@ CONTEXT PrototypeFramework IN ENGLISH
         ]
 
     --[SYSTEM INTERFACES to query menu items]------------------------------------------------------
-    API "PF_MenuItems" FOR SYSTEM: sessionActiveRoles[SESSION*Role];pf_navItemRoles~;isVisible BOX
+    API "PF_MenuItems" FOR SYSTEM: sessionActiveRoles[SESSION*PF_Role];pf_navItemRoles~;isVisible BOX
         [ "id"              : I
         , "label"           : label
         , "seqNr"           : seqNr

--- a/AmpersandData/PrototypeContext/PrototypeContext.adl
+++ b/AmpersandData/PrototypeContext/PrototypeContext.adl
@@ -8,8 +8,8 @@ CONTEXT PrototypeContxt IN ENGLISH
 
   INCLUDE "Roles.adl"
 
-  RELATION sessionAllowedRoles[SESSION*Role]
-  RELATION sessionActiveRoles[SESSION*Role]
+  RELATION sessionAllowedRoles[SESSION*PF_Role]
+  RELATION sessionActiveRoles[SESSION*PF_Role]
   
   RULE "Active roles MUST be a subset of allowed roles": -- This rule is required for the access control mechanism.
      sessionActiveRoles |- sessionAllowedRoles           -- It ensures that only allowed roles can be activated.

--- a/AmpersandData/PrototypeContext/PrototypeContext.docadl
+++ b/AmpersandData/PrototypeContext/PrototypeContext.docadl
@@ -13,10 +13,10 @@ PATTERN SystemSpecific
   {+Sessies zijn nodig om de dialoog aan te kunnen duiden tussen de gebruiker en de computer+}
   PURPOSE CONCEPT SESSION IN ENGLISH
   {+Sessions are required to allow for associating information with individual visitors+}
-  CONCEPT Role "een functie of onderdeel die speciaal in een bepaalde bewerking of proces wordt uitgevoerd"
-  PURPOSE CONCEPT Role IN DUTCH
+  CONCEPT PF_Role "een functie of onderdeel die speciaal in een bepaalde bewerking of proces wordt uitgevoerd"
+  PURPOSE CONCEPT PF_Role IN DUTCH
   {+We hebben rollen nodig om een basale vorm van beveiliging te implementeren, gebaseerd op permissies. +}
-  PURPOSE CONCEPT Role IN ENGLISH
+  PURPOSE CONCEPT PF_Role IN ENGLISH
   {+We need roles to implement a basic form of security based on permissions. +}
   CONCEPT DateTime "een specifiek moment, tijdstip"
   PURPOSE CONCEPT DateTime IN DUTCH
@@ -32,7 +32,7 @@ PATTERN SystemSpecific
   PURPOSE RELATION lastAccess IN ENGLISH
   {+A session can be active at some moment in time. This relation holds the information when that was for the last time.+}
 
-  RELATION sessionAllowedRoles[SESSION*Role] -- This definition is only needed for `MEANING` to be interpreted correctly.
+  RELATION sessionAllowedRoles[SESSION*PF_Role] -- This definition is only needed for `MEANING` to be interpreted correctly.
   MEANING IN DUTCH "een rol kan zijn toegestaan gedurende een sessie"
   MEANING IN ENGLISH "a role can be allowed during a session"
   PURPOSE RELATION sessionAllowedRoles IN DUTCH
@@ -40,7 +40,7 @@ PATTERN SystemSpecific
   PURPOSE RELATION sessionAllowedRoles IN ENGLISH
   {+A user can be granted specific roles.+}
 
-  RELATION sessionActiveRoles[SESSION*Role] -- This definition is only needed for `MEANING` to be interpreted correctly.
+  RELATION sessionActiveRoles[SESSION*PF_Role] -- This definition is only needed for `MEANING` to be interpreted correctly.
   MEANING IN DUTCH "een rol kan in gebruik zijn gedurende een sessie"
   MEANING IN ENGLISH "a role can be active during a session"
   PURPOSE RELATION sessionActiveRoles IN DUTCH

--- a/AmpersandData/PrototypeContext/Roles.adl
+++ b/AmpersandData/PrototypeContext/Roles.adl
@@ -1,14 +1,14 @@
 CONTEXT PrototypeFramework IN ENGLISH
 
-    CONCEPT Role ""
-        REPRESENT Role TYPE OBJECT
-        POPULATION Role CONTAINS ["Anonymous"] -- at least one role is needed, because nav items are filtered using 'sessionActiveRoles'. Anonymous is part of SIAMv3
+    CONCEPT PF_Role ""
+        REPRESENT PF_Role TYPE OBJECT
+        POPULATION PF_Role CONTAINS ["Anonymous"] -- at least one role is needed, because nav items are filtered using 'sessionActiveRoles'. Anonymous is part of SIAMv3
     
-    RELATION label[Role*PF_Label] [UNI,TOT]
+    RELATION label[PF_Role*PF_Label] [UNI,TOT]
         REPRESENT PF_Label TYPE ALPHANUMERIC
-        POPULATION label[Role*PF_Label] CONTAINS [ ("Anonymous", "Anonymous") ]
+        POPULATION label[PF_Role*PF_Label] CONTAINS [ ("Anonymous", "Anonymous") ]
 
-    API "PF_AllRoles" FOR SYSTEM : V[ONE*Role] BOX
+    API "PF_AllRoles" FOR SYSTEM : V[ONE*PF_Role] BOX
         [ "id"              : I
         , "label"           : label
         -- , "maintains"       : 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,7 @@
 ﻿# Release notes of Ampersand
 
 ## Unreleased changes
+* [Issue #1045](https://github.com/AmpersandTarski/Ampersand/issues/1045) Rename Role into PF_Role in PrototypeContext.
 * [Issue #1067](https://github.com/AmpersandTarski/Ampersand/issues/1067) Docker build push to Docker hub instead of Github package repo
 * [Issue #1084](https://github.com/AmpersandTarski/Ampersand/issues/1084) Add template attributes to BOX syntax
 * **Breaking change** Because of the implementation of feature of #1084 we could greatly reduce the number of BOX templates (e.g. ROWS, ROWSNL, HROWS and HROWSNL are merged into a single template). Documentation of new templates can be found [here](https://github.com/AmpersandTarski/prototype/tree/master/templates). 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,7 +1,10 @@
 ﻿# Release notes of Ampersand
 
 ## Unreleased changes
-* [Issue #1045](https://github.com/AmpersandTarski/Ampersand/issues/1045) Rename Role into PF_Role in PrototypeContext.
+* **Breaking change** [Issue #1045](https://github.com/AmpersandTarski/Ampersand/issues/1045) Rename Role into PF_Role in PrototypeContext. Scripts that depend on or extend the concept 'Role' (e.g. scripts that use SIAM) must add:
+
+  `CONCEPT Role ISA PF_Role` ór `CONCEPT PF_Role ISA Role` depending on the use case. For some scripts this migth not work out. In that case a rename to PF_Role is needed.
+
 * [Issue #1067](https://github.com/AmpersandTarski/Ampersand/issues/1067) Docker build push to Docker hub instead of Github package repo
 * [Issue #1084](https://github.com/AmpersandTarski/Ampersand/issues/1084) Add template attributes to BOX syntax
 * **Breaking change** Because of the implementation of feature of #1084 we could greatly reduce the number of BOX templates (e.g. ROWS, ROWSNL, HROWS and HROWSNL are merged into a single template). Documentation of new templates can be found [here](https://github.com/AmpersandTarski/prototype/tree/master/templates). 

--- a/src/Ampersand/FSpec/Transformers.hs
+++ b/src/Ampersand/FSpec/Transformers.hs
@@ -855,7 +855,7 @@ transformersPrototypeContext fSpec = map toTransformer [
     , ("label"                 , "PF_NavMenuItem"        , "PF_Label"
       , Set.empty
       )
-    , ("label"                 , "Role"               , "PF_Label"
+    , ("label"                 , "PF_Role"               , "PF_Label"
       , Set.fromList $
         [ (dirtyIdWithoutType role, PopAlphaNumeric . name $ role)
         | role::Role <- instanceList fSpec
@@ -864,23 +864,23 @@ transformersPrototypeContext fSpec = map toTransformer [
     , ("lastAccess"            , "SESSION"               , "DateTime"
       , Set.empty
       )
-    , ("pf_ifcRoles"           , "PF_Interface"          , "Role"
+    , ("pf_ifcRoles"           , "PF_Interface"          , "PF_Role"
       , Set.fromList $
         [(dirtyIdWithoutType ifc , dirtyIdWithoutType role)
         | ifc::Interface <- instanceList fSpec
         , role <- ifcRoles ifc
         ]
       )
-    , ("pf_navItemRoles"       , "PF_NavMenuItem"        , "Role"
+    , ("pf_navItemRoles"       , "PF_NavMenuItem"        , "PF_Role"
       , Set.empty
       )
     , ("seqNr"                 , "PF_NavMenuItem"        , "PF_SeqNr"
       , Set.empty
       )
-    , ("sessionActiveRoles"    , "SESSION"               , "Role"
+    , ("sessionActiveRoles"    , "SESSION"               , "PF_Role"
       , Set.empty
       )
-    , ("sessionAllowedRoles"   , "SESSION"               , "Role"
+    , ("sessionAllowedRoles"   , "SESSION"               , "PF_Role"
       , Set.empty
       )
     , ("url"                   , "PF_NavMenuItem"        , "PF_URL"


### PR DESCRIPTION
Relates to #1045

**Breaking change**
Rename Role into PF_Role in PrototypeContext.

Scripts that depend on or extend the concept 'Role' (e.g. scripts that use SIAM) must add: `CONCEPT Role ISA PF_Role` ór `CONCEPT PF_Role ISA Role` depending on the use case. For some scripts this migth not work out. In that case a rename to PF_Role is needed.