### PR TITLE
Feature/ghc 9

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM haskell:8.10.7 
+FROM haskell:9.0.2 
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
@@ -40,6 +40,6 @@ ARG COMMON_SCRIPT_SHA="dev-mode"
 
 # RUN curl -sSL https://get.haskellstack.org/ | sh
 
-RUN stack install ormolu-0.1.4.1
+RUN stack install ormolu-0.3.1.0
 
 USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "HaskellStackDev:8.10.7",
+  "name": "HaskellStackDev:9.0.2",
   "dockerFile": "Dockerfile",
   "runArgs": [],
   // Use 'settings' to set *default* container specific settings.json values on container create. 

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -63,7 +63,7 @@ jobs:
           stack-arguments: "--copy-bins --flag ampersand:buildAll"
       # Weeder needs compilation artifacts, so it must still be the same Job
       - name: Check weeds🌿🌿🌿
-      - uses: freckle/weeder-action@v1
+        uses: freckle/weeder-action@v1
 
   build-and-test-macOS:
     name: Build and test on macOS  🏗 🧪

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -61,10 +61,9 @@ jobs:
         uses: freckle/stack-action@v3 # stack-action does all these steps: dependencies, build, test.
         with:
           stack-arguments: "--copy-bins --flag ampersand:buildAll"
+      # Weeder needs compilation artifacts, so it must still be the same Job
       - name: Check weeds🌿🌿🌿
-        uses: freckle/stack-action@v1
-        with:
-          weeder: true
+      - uses: freckle/weeder-action@v1
 
   build-and-test-macOS:
     name: Build and test on macOS  🏗 🧪
@@ -83,9 +82,7 @@ jobs:
         with:
           stack-arguments: "--copy-bins --flag ampersand:buildAll"
       - name: Check weeds🌿🌿🌿
-        uses: freckle/stack-action@v1
-        with:
-          weeder: true
+        uses: freckle/weeder-action@v1
 
   build-and-test-windows:
     name: Build and test on Windows 🏗 🧪
@@ -116,6 +113,4 @@ jobs:
         with:
           stack-arguments: "--copy-bins --flag ampersand:buildAll"
       - name: Check weeds🌿🌿🌿
-        uses: freckle/stack-action@v1
-        with:
-          weeder: true
+        uses: freckle/weeder-action@v1

--- a/.github/workflows/ormolu-formatting-code.yml
+++ b/.github/workflows/ormolu-formatting-code.yml
@@ -10,11 +10,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
-  # Enforces the use of ormolu formatting of each Haskell file on every pull request 
+  # Enforces the use of ormolu formatting of each Haskell file on every pull request
   ormolu:
     runs-on: ubuntu-latest
     steps:
-    # The checkout step is needed since the enforcer relies on local git commands
-    - uses: actions/checkout@v2
-    
-    - uses: mrkkrp/ormolu-action@v2 # BEWARE: Do not upgrade unless we use ghc 9 or higher. v4 does not work for ghc less then 9.
+      # The checkout step is needed since the enforcer relies on local git commands
+      - uses: actions/checkout@v2
+
+      - uses: mrkkrp/ormolu-action@v2 # BEWARE: Do not upgrade unless we use ghc 9 or higher. v4 does not work for ghc less then 9.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # The purpose of this docker file is to produce a latest Ampersand-compiler in the form of a docker image.
-FROM haskell:8.10.7 AS buildstage
+FROM haskell:9.0.2 AS buildstage
 
 
 RUN mkdir /opt/ampersand

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,7 @@
 * [Issue #1267](https://github.com/AmpersandTarski/Ampersand/issues/1267) Automatically add ReleaseNotes to release artefacts
 * [Issue #1275](https://github.com/AmpersandTarski/Ampersand/issues/1275) Fix duplicate pattern bug
 * Bugfix grinding metapopulation for Prototypes. Bug was introduced by a refactoring done in v4.3.0
+* Switch to GHC 9
 
 ## v4.6.2 (2 December 2021)
 

--- a/ampersand.cabal
+++ b/ampersand.cabal
@@ -19,7 +19,7 @@ license:        GPL
 license-file:   LICENSE
 build-type:     Custom
 tested-with:
-    GHC == 8.10.7
+    GHC == 9.0.2
 extra-source-files:
     LICENSE
     ReleaseNotes.md
@@ -400,14 +400,14 @@ extra-source-files:
 
 custom-setup
   setup-depends:
-      Cabal ==3.2.1.0
-    , base ==4.14.3.0
+      Cabal ==3.4.1.0
+    , base ==4.15.1.0
     , bytestring ==0.10.*
     , directory ==1.3.*
     , filepath ==1.4.*
     , process ==1.6.*
     , rio ==0.1.*
-    , salve ==1.0.11
+    , salve ==2.0.*
     , time ==1.9.3
     , zip-archive >=0.4.1
 
@@ -574,35 +574,35 @@ library
       HStringTemplate ==0.8.*
     , QuickCheck ==2.14.2
     , SpreadsheetML ==0.1.*
-    , aeson ==1.5.6.0
+    , aeson ==2.0.3.0
     , aeson-pretty ==0.8.*
     , ansi-terminal ==0.11.*
-    , base ==4.14.3.0
+    , base ==4.15.1.0
     , bytestring ==0.10.*
     , conduit ==1.3.*
     , containers ==0.6.*
     , data-default ==0.7.*
     , directory ==1.3.*
-    , doctemplates ==0.9
+    , doctemplates ==0.10.*
     , extra >=1.6.6
     , filepath ==1.4.*
     , fsnotify ==0.3.*
     , generic-deriving
     , graphviz ==2999.20.*
-    , hashable ==1.3.0.0
+    , hashable ==1.3.5.0
     , http-conduit ==2.3.*
     , hxt ==9.3.*
-    , lens ==4.19.2
+    , lens ==5.0.1
     , mtl ==2.2.*
     , optparse-applicative ==0.16.*
-    , pandoc ==2.14.*
+    , pandoc ==2.17.*
     , pandoc-crossref ==0.3.12.*
     , pandoc-types ==1.22.*
     , parsec ==3.1.*
     , process ==1.6.*
     , quickcheck-instances
     , rio ==0.1.*
-    , salve ==1.*
+    , salve ==2.0.*
     , simple-sql-parser ==0.4.4
     , split ==0.2.*
     , terminal-size ==0.3.*
@@ -613,8 +613,7 @@ library
     , typed-process ==0.2.*
     , wl-pprint ==1.2.*
     , xlsx ==0.8.*
-    , yaml ==0.11.*
-    , yaml-config ==0.4.*
+    , yaml ==0.11.8.*
     , zip-archive >=0.4.1
   if os(windows)
     build-depends:
@@ -638,36 +637,36 @@ executable ampPreProc
       HStringTemplate ==0.8.*
     , QuickCheck ==2.14.2
     , SpreadsheetML ==0.1.*
-    , aeson ==1.5.6.0
+    , aeson ==2.0.3.0
     , aeson-pretty ==0.8.*
     , ampersand
     , ansi-terminal ==0.11.*
-    , base ==4.14.3.0
+    , base ==4.15.1.0
     , bytestring ==0.10.*
     , conduit ==1.3.*
     , containers ==0.6.*
     , data-default ==0.7.*
     , directory ==1.3.*
-    , doctemplates ==0.9
+    , doctemplates ==0.10.*
     , extra >=1.6.6
     , filepath ==1.4.*
     , fsnotify ==0.3.*
     , generic-deriving
     , graphviz ==2999.20.*
-    , hashable ==1.3.0.0
+    , hashable ==1.3.5.0
     , http-conduit ==2.3.*
     , hxt ==9.3.*
-    , lens ==4.19.2
+    , lens ==5.0.1
     , mtl ==2.2.*
     , optparse-applicative ==0.16.*
-    , pandoc ==2.14.*
+    , pandoc ==2.17.*
     , pandoc-crossref ==0.3.12.*
     , pandoc-types ==1.22.*
     , parsec ==3.1.*
     , process ==1.6.*
     , quickcheck-instances
     , rio ==0.1.*
-    , salve ==1.*
+    , salve ==2.0.*
     , simple-sql-parser ==0.4.4
     , split ==0.2.*
     , terminal-size ==0.3.*
@@ -678,8 +677,7 @@ executable ampPreProc
     , typed-process ==0.2.*
     , wl-pprint ==1.2.*
     , xlsx ==0.8.*
-    , yaml ==0.11.*
-    , yaml-config ==0.4.*
+    , yaml ==0.11.8.*
     , zip-archive >=0.4.1
   if os(windows)
     build-depends:
@@ -702,40 +700,40 @@ executable ampersand
       OverloadedStrings
   ghc-options: -Wall -Wcompat -Widentities -optP-Wno-nonportable-include-path -Wredundant-constraints -threaded -fwrite-ide-info
   build-depends:
-      Cabal ==3.2.1.0
+      Cabal ==3.4.1.0
     , HStringTemplate ==0.8.*
     , QuickCheck ==2.14.2
     , SpreadsheetML ==0.1.*
-    , aeson ==1.5.6.0
+    , aeson ==2.0.3.0
     , aeson-pretty ==0.8.*
     , ampersand
     , ansi-terminal ==0.11.*
-    , base ==4.14.3.0
+    , base ==4.15.1.0
     , bytestring ==0.10.*
     , conduit ==1.3.*
     , containers ==0.6.*
     , data-default ==0.7.*
     , directory ==1.3.*
-    , doctemplates ==0.9
+    , doctemplates ==0.10.*
     , extra >=1.6.6
     , filepath ==1.4.*
     , fsnotify ==0.3.*
     , generic-deriving
     , graphviz ==2999.20.*
-    , hashable ==1.3.0.0
+    , hashable ==1.3.5.0
     , http-conduit ==2.3.*
     , hxt ==9.3.*
-    , lens ==4.19.2
+    , lens ==5.0.1
     , mtl ==2.2.*
     , optparse-applicative ==0.16.*
-    , pandoc ==2.14.*
+    , pandoc ==2.17.*
     , pandoc-crossref ==0.3.12.*
     , pandoc-types ==1.22.*
     , parsec ==3.1.*
     , process ==1.6.*
     , quickcheck-instances
     , rio ==0.1.*
-    , salve ==1.*
+    , salve ==2.0.*
     , simple-sql-parser ==0.4.4
     , split ==0.2.*
     , terminal-size ==0.3.*
@@ -746,8 +744,7 @@ executable ampersand
     , typed-process ==0.2.*
     , wl-pprint ==1.2.*
     , xlsx ==0.8.*
-    , yaml ==0.11.*
-    , yaml-config ==0.4.*
+    , yaml ==0.11.8.*
     , zip-archive >=0.4.1
   if os(windows)
     build-depends:
@@ -772,36 +769,36 @@ test-suite ampersand-test
       HStringTemplate ==0.8.*
     , QuickCheck ==2.14.2
     , SpreadsheetML ==0.1.*
-    , aeson ==1.5.6.0
+    , aeson ==2.0.3.0
     , aeson-pretty ==0.8.*
     , ampersand
     , ansi-terminal ==0.11.*
-    , base ==4.14.3.0
+    , base ==4.15.1.0
     , bytestring ==0.10.*
     , conduit ==1.3.*
     , containers ==0.6.*
     , data-default ==0.7.*
     , directory ==1.3.*
-    , doctemplates ==0.9
+    , doctemplates ==0.10.*
     , extra >=1.6.6
     , filepath ==1.4.*
     , fsnotify ==0.3.*
     , generic-deriving
     , graphviz ==2999.20.*
-    , hashable ==1.3.0.0
+    , hashable ==1.3.5.0
     , http-conduit ==2.3.*
     , hxt ==9.3.*
-    , lens ==4.19.2
+    , lens ==5.0.1
     , mtl ==2.2.*
     , optparse-applicative ==0.16.*
-    , pandoc ==2.14.*
+    , pandoc ==2.17.*
     , pandoc-crossref ==0.3.12.*
     , pandoc-types ==1.22.*
     , parsec ==3.1.*
     , process ==1.6.*
     , quickcheck-instances
     , rio ==0.1.*
-    , salve ==1.*
+    , salve ==2.0.*
     , simple-sql-parser ==0.4.4
     , split ==0.2.*
     , terminal-size ==0.3.*
@@ -812,8 +809,7 @@ test-suite ampersand-test
     , typed-process ==0.2.*
     , wl-pprint ==1.2.*
     , xlsx ==0.8.*
-    , yaml ==0.11.*
-    , yaml-config ==0.4.*
+    , yaml ==0.11.8.*
     , zip-archive >=0.4.1
   if os(windows)
     build-depends:

--- a/ampersand.cabal
+++ b/ampersand.cabal
@@ -603,7 +603,7 @@ library
     , quickcheck-instances
     , rio ==0.1.*
     , salve ==2.0.*
-    , simple-sql-parser ==0.4.4
+    , simple-sql-parser ==0.6.0
     , split ==0.2.*
     , terminal-size ==0.3.*
     , texmath ==0.12.*
@@ -667,7 +667,7 @@ executable ampPreProc
     , quickcheck-instances
     , rio ==0.1.*
     , salve ==2.0.*
-    , simple-sql-parser ==0.4.4
+    , simple-sql-parser ==0.6.0
     , split ==0.2.*
     , terminal-size ==0.3.*
     , texmath ==0.12.*
@@ -734,7 +734,7 @@ executable ampersand
     , quickcheck-instances
     , rio ==0.1.*
     , salve ==2.0.*
-    , simple-sql-parser ==0.4.4
+    , simple-sql-parser ==0.6.0
     , split ==0.2.*
     , terminal-size ==0.3.*
     , texmath ==0.12.*
@@ -799,7 +799,7 @@ test-suite ampersand-test
     , quickcheck-instances
     , rio ==0.1.*
     , salve ==2.0.*
-    , simple-sql-parser ==0.4.4
+    , simple-sql-parser ==0.6.0
     , split ==0.2.*
     , terminal-size ==0.3.*
     , texmath ==0.12.*

--- a/package.yaml
+++ b/package.yaml
@@ -65,7 +65,7 @@ dependencies:
   - quickcheck-instances
   - rio == 0.1.*
   - salve == 2.0.*
-  - simple-sql-parser == 0.4.4
+  - simple-sql-parser == 0.6.0
   - split == 0.2.*
   - SpreadsheetML == 0.1.*
   - terminal-size == 0.3.*

--- a/package.yaml
+++ b/package.yaml
@@ -7,7 +7,7 @@ description: You can define your business processes by means of rules, written i
 homepage: http://ampersandtarski.github.io/
 category: Database Design
 stability: alpha
-tested-with: GHC == 8.10.7
+tested-with: GHC == 9.0.2
 build-type: Custom
 license: GPL
 license-file: LICENSE
@@ -34,29 +34,29 @@ default-extensions:
   - NoImplicitPrelude
   - OverloadedStrings
 dependencies:
-  - aeson == 1.5.6.0
+  - aeson == 2.0.3.0
   - aeson-pretty == 0.8.*
   - ansi-terminal == 0.11.*
-  - base == 4.14.3.0
+  - base == 4.15.1.0
   - bytestring == 0.10.*
   - conduit == 1.3.*
   - containers == 0.6.*
   - data-default == 0.7.*
   - directory == 1.3.*
-  - doctemplates == 0.9
+  - doctemplates == 0.10.*
   - extra >= 1.6.6
   - filepath == 1.4.*
   - fsnotify == 0.3.*
   - generic-deriving
   - graphviz == 2999.20.*
-  - hashable == 1.3.0.0
+  - hashable == 1.3.5.0
   - HStringTemplate == 0.8.*
   - http-conduit == 2.3.*
   - hxt == 9.3.*
-  - lens == 4.19.2
+  - lens == 5.0.1
   - mtl == 2.2.*
   - optparse-applicative == 0.16.*
-  - pandoc == 2.14.*
+  - pandoc == 2.17.*
   - pandoc-crossref == 0.3.12.*
   - pandoc-types == 1.22.*
   - parsec == 3.1.*
@@ -64,7 +64,7 @@ dependencies:
   - QuickCheck == 2.14.2
   - quickcheck-instances
   - rio == 0.1.*
-  - salve == 1.*
+  - salve == 2.0.*
   - simple-sql-parser == 0.4.4
   - split == 0.2.*
   - SpreadsheetML == 0.1.*
@@ -76,8 +76,7 @@ dependencies:
   - typed-process == 0.2.*
   - wl-pprint == 1.2.*
   - xlsx == 0.8.*
-  - yaml == 0.11.*
-  - yaml-config == 0.4.*
+  - yaml == 0.11.8.*
   - zip-archive >= 0.4.1
 when:
   - condition: os(windows)
@@ -199,15 +198,15 @@ library:
     - Ampersand.Prototype.StaticFiles_Generated
 custom-setup:
   dependencies:
-    - base == 4.14.3.0
+    - base == 4.15.1.0
     - bytestring == 0.10.*
-    - Cabal == 3.2.1.0
+    - Cabal == 3.4.1.0
     - directory == 1.3.*
     - filepath == 1.4.*
     - process == 1.6.*
     - rio == 0.1.*
     - time == 1.9.3
-    - salve == 1.0.11
+    - salve == 2.0.*
     - zip-archive >= 0.4.1
 
 executables:
@@ -220,7 +219,7 @@ executables:
       - -fwrite-ide-info
     dependencies:
       - ampersand
-      - Cabal == 3.2.1.0
+      - Cabal == 3.4.1.0
 
   ampPreProc:
     source-dirs:

--- a/src/Ampersand/Basics/Languages.hs
+++ b/src/Ampersand/Basics/Languages.hs
@@ -49,7 +49,7 @@ plural Dutch str =
           | "ij" `T.isSuffixOf` str = str <> "en"
           | "io" `T.isSuffixOf` str = str <> "'s"
           | klinker last = str <> "s"
-          | (T.take 2 . T.drop 1 . T.reverse) str `elem` ["aa", "oo", "ee", "uu"] = (T.reverse . T.drop 2 . T.reverse) str <> mede (T.drop (T.length str -1) str) <> "en"
+          | (T.take 2 . T.drop 1 . T.reverse) str `elem` ["aa", "oo", "ee", "uu"] = (T.reverse . T.drop 2 . T.reverse) str <> mede (T.drop (T.length str - 1) str) <> "en"
           | otherwise = str <> "en"
         last = case T.uncons . T.reverse $ tl of
           Nothing -> h

--- a/src/Ampersand/Basics/Version.hs
+++ b/src/Ampersand/Basics/Version.hs
@@ -33,7 +33,7 @@ fatal msg =
       Just (h, tl)
         | T.null tl -> mempty
         | n == 0 -> "\n<Ampersand's fatal-mechanism has removed the rest of this error message.>"
-        | otherwise -> T.cons h (lazyCutoff (n -1) tl)
+        | otherwise -> T.cons h (lazyCutoff (n - 1) tl)
 {-# NOINLINE fatal #-}
 
 data VersionInfo = VersionInfo

--- a/src/Ampersand/Commands/Daemon.hs
+++ b/src/Ampersand/Commands/Daemon.hs
@@ -67,7 +67,7 @@ mainWithTerminal termSize termOutput = goForever
               return $
                 TermSize
                   (termWidth term - 1)
-                  (termHeight term -1)
+                  (termHeight term - 1)
                   (termWrap term)
 
           restyle <- liftIO $ do
@@ -287,11 +287,11 @@ withCurrentDirectory dir act =
       )
   where
     bracket' ::
-      -- | computation to run first (\"acquire resource\")
+      -- computation to run first (\"acquire resource\")
       IO a ->
-      -- | computation to run last (\"release resource\")
+      -- computation to run last (\"release resource\")
       (a -> IO b) ->
-      -- | computation to run in-between
+      -- computation to run in-between
       (a -> RIO env c) ->
       RIO env c -- returns the value from the in-between computation
     bracket' before after thing =

--- a/src/Ampersand/Daemon/Escape.hs
+++ b/src/Ampersand/Daemon/Escape.hs
@@ -94,7 +94,7 @@ splitAtE i e = case unesc e of
   _ | i <= 0 -> (Esc "", e)
   Nothing -> (e, e)
   Just (Left code, rest) -> first (app code) $ splitAtE i rest
-  Just (Right c, rest) -> first (app $ Esc [c]) $ splitAtE (i -1) rest
+  Just (Right c, rest) -> first (app $ Esc [c]) $ splitAtE (i - 1) rest
 
 reverseE :: Esc -> Esc
 reverseE = implode . reverse . explode

--- a/src/Ampersand/FSpec/SQL.hs
+++ b/src/Ampersand/FSpec/SQL.hs
@@ -532,7 +532,7 @@ nonSpecialSelectExpr fSpec expr =
                                   bseTbl = zipWith tableRef [0 ..] es,
                                   bseWhr =
                                     Just . conjunctSQL . concatMap constraintsOfTailExpression $
-                                      [1 .. length es -1]
+                                      [1 .. length es - 1]
                                 }
                             where
                               iSect :: Int -> Name
@@ -1341,8 +1341,10 @@ sqlAttConcept fSpec c
 
 stringOfName :: Name -> Text
 stringOfName (Name _ s) = T.pack s
+
 qName :: Text -> Name
-qName = Name (Just (['"'],['"'])) . T.unpack
+qName = Name (Just (['"'], ['"'])) . T.unpack
+
 noQuotes :: Text -> Name
 noQuotes = Name Nothing . T.unpack
 

--- a/src/Ampersand/FSpec/SQL.hs
+++ b/src/Ampersand/FSpec/SQL.hs
@@ -124,7 +124,7 @@ class SQLAble a where
                     Nothing -> placeHolder
                     Just whr -> conjunctSQL [placeHolder, whr]
               }
-          placeHolder = BinOp (col2ScalarExpr (bseSrc bqe)) [Name Nothing "="] (StringLit "'" "'" $ T.unpack placeHolderSQL)
+          placeHolder = BinOp (col2ScalarExpr (bseSrc bqe)) [noQuotes "="] (StringLit "'" "'" $ T.unpack placeHolderSQL)
 
 instance SQLAble Expression where
   getBinQueryExpr fSpec = setDistinct . selectExpr fSpec

--- a/src/Ampersand/FSpec/ToFSpec/NormalForms.hs
+++ b/src/Ampersand/FSpec/ToFSpec/NormalForms.hs
@@ -918,7 +918,7 @@ separate n s = [(part, s `Set.difference` part) | part <- subsetLength n (Set.to
   where
     subsetLength :: Ord a => Int -> [a] -> [Set a]
     subsetLength 0 _ = [Set.empty]
-    subsetLength i (x : xs) = map (Set.insert x) (subsetLength (i -1) xs) <> subsetLength i xs
+    subsetLength i (x : xs) = map (Set.insert x) (subsetLength (i - 1) xs) <> subsetLength i xs
     subsetLength _ [] = []
 
 -- parts produces a fixed number of subsets
@@ -929,7 +929,7 @@ parts n = Set.toList . Set.fromList . map (Set.fromList . map Set.fromList) . p 
     p 0 _ = []
     p 1 xs = [[xs]]
     p 2 xs = [[ss, rest] | ss <- init (subsets xs), let rest = [e | e <- xs, e `notElem` ss], not (null rest)]
-    p i xs = [twoSets <> tl | (hd : tl) <- p (i -1) xs, twoSets <- p 2 hd]
+    p i xs = [twoSets <> tl | (hd : tl) <- p (i - 1) xs, twoSets <- p 2 hd]
     {- examples:
        parts 1 "abcd" = {{"abcd"}}
        parts 2 "abcd" = {{"a","bcd"},{"ab","cd"},{"abc","d"},{"abd","c"},{"ac","bd"},{"acd","b"},{"ad","bc"}}
@@ -1863,8 +1863,8 @@ init = fromMaybe (fatal "Illegal use of init") . L.initMaybe
 --   will result in the original list.
 dist :: Int -> [a] -> [[[a]]]
 dist 1 ls = [[ls]]
-dist 2 ls = [[take i ls, drop i ls] | i <- [1 .. length ls -1]]
-dist n ls = [init ds <> st | ds <- dist (n -1) ls, let staart = last ds, length staart >= 2, st <- dist 2 staart]
+dist 2 ls = [[take i ls, drop i ls] | i <- [1 .. length ls - 1]]
+dist n ls = [init ds <> st | ds <- dist (n - 1) ls, let staart = last ds, length staart >= 2, st <- dist 2 staart]
 
 {- examples:
 dist 1 "abcd" = [["abcd"]]

--- a/src/Ampersand/Input/ADL1/CtxError.hs
+++ b/src/Ampersand/Input/ADL1/CtxError.hs
@@ -459,7 +459,7 @@ mkInvariantViolationsError applyViolText (r, ps) =
         [] -> []
         h : tl
           | i == 0 -> ["  ... (" <> tshow (length xs) <> " more)"]
-          | otherwise -> applyViolText r h : listPairs (i -1) tl
+          | otherwise -> applyViolText r h : listPairs (i - 1) tl
 
 mkInterfaceRefCycleError :: NE.NonEmpty Interface -> CtxError
 mkInterfaceRefCycleError cyclicIfcs =

--- a/src/Ampersand/Input/ADL1/FilePos.hs
+++ b/src/Ampersand/Input/ADL1/FilePos.hs
@@ -57,7 +57,7 @@ addTab ::
   FilePos
 addTab pos@(FilePos _ _ col) = addPos tabWidth pos
   where
-    tabWidth = 8 - ((col -1) `mod` 8)
+    tabWidth = 8 - ((col - 1) `mod` 8)
 
 -- | Adds one column to the file position
 addPos :: Int -> FilePos -> FilePos

--- a/src/Ampersand/Input/Xslx/XLSX.hs
+++ b/src/Ampersand/Input/Xslx/XLSX.hs
@@ -340,11 +340,11 @@ toPops env file x = map popForColumn (colNrs x)
             origSrc = XLSXLoc file (theSheetName x) (r, sourceCol)
             origTrg = XLSXLoc file (theSheetName x) (r, targetCol)
         cellToAtomValues ::
-          -- | the delimiter, if there is any, used as seperator for multiple values in the cell
+          -- the delimiter, if there is any, used as seperator for multiple values in the cell
           Maybe Char ->
-          -- | The value that is read from the cell
+          -- The value that is read from the cell
           CellValue ->
-          -- | the origin of the value.
+          -- the origin of the value.
           Origin ->
           [PAtomValue]
         cellToAtomValues mDelimiter cv orig =
@@ -446,8 +446,8 @@ theSheetCellsForTable (sheetName, ws) =
           Nothing -> fatal "Maximum of an empty list is not defined!"
           Just m -> m
         firstPopRowNr = firstHeaderRowNr + nrOfHeaderRows
-        lastPopRowNr = ((map fst tableStarters <> [maxRowOfWorksheet + 1]) `L.genericIndex` (indexInTableStarters + 1)) -1
-        okHeaderRows = filter isProperRow [firstHeaderRowNr, firstHeaderRowNr + nrOfHeaderRows -1]
+        lastPopRowNr = ((map fst tableStarters <> [maxRowOfWorksheet + 1]) `L.genericIndex` (indexInTableStarters + 1)) - 1
+        okHeaderRows = filter isProperRow [firstHeaderRowNr, firstHeaderRowNr + nrOfHeaderRows - 1]
         populationRows = filter isProperRow [firstPopRowNr .. lastPopRowNr]
         isProperRow :: Int -> Bool
         isProperRow rowNr

--- a/src/Ampersand/Output/FSpec2SQL.hs
+++ b/src/Ampersand/Output/FSpec2SQL.hs
@@ -80,7 +80,7 @@ header :: Text -> [Text]
 header title =
   [ "/*",
     T.replicate width "*",
-    "***" <> spaces firstspaces <> title <> spaces (width -6 - firstspaces - l) <> "***",
+    "***" <> spaces firstspaces <> title <> spaces (width - 6 - firstspaces - l) <> "***",
     T.replicate width "*",
     "*/"
   ]

--- a/src/Ampersand/Output/PredLogic.hs
+++ b/src/Ampersand/Output/PredLogic.hs
@@ -52,7 +52,7 @@ showPredLogic lang expr = text $ predLshow lang varMap (predNormalize predL)
     -- For printing a variable we use varMap
     -- A variable is represented by the first character of its concept name, followed by a number of primes to distinguish from similar variables.
     varMap :: Var -> Text
-    varMap (Var n c) = vChar c <> (T.pack . replicate (length vars -1)) '\''
+    varMap (Var n c) = vChar c <> (T.pack . replicate (length vars - 1)) '\''
       where
         vars = Set.filter (\(Var i c') -> i <= n && vChar c == vChar c') varSet
         vChar = T.toLower . T.take 1 . name

--- a/src/Ampersand/Output/ToJSON/JSONutils.hs
+++ b/src/Ampersand/Output/ToJSON/JSONutils.hs
@@ -21,7 +21,7 @@ import Ampersand.Classes
 import Ampersand.Core.ParseTree (Role, ViewHtmlTemplate (ViewHtmlTemplateFile))
 import Ampersand.Core.ShowAStruct
 import Ampersand.FSpec.FSpec
-import Ampersand.FSpec.SQL (broadQueryWithPlaceholder, placeHolderSQL, sqlQuery, sqlQueryWithPlaceholder)
+import Ampersand.FSpec.SQL (broadQueryWithPlaceholder, sqlQuery, sqlQueryWithPlaceholder)
 import Ampersand.FSpec.ToFSpec.Populated
 import Ampersand.Misc.HasClasses
 import Data.Aeson hiding (Options)

--- a/src/Ampersand/Output/ToPandoc/ChapterDiagnosis.hs
+++ b/src/Ampersand/Output/ToPandoc/ChapterDiagnosis.hs
@@ -727,7 +727,7 @@ chpDiagnosis env fSpec
             [] -> []
             h : tl
               | i == 0 -> ["  ... (" <> tshow (length xs) <> " more)"]
-              | otherwise -> applyViolText' r h : listPairs (i -1) tl
+              | otherwise -> applyViolText' r h : listPairs (i - 1) tl
 
     violtable :: Rule -> AAtomPairs -> Blocks
     violtable r ps =

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,7 +13,7 @@ extra-deps:
   - pandoc-crossref-0.3.12.2@sha256:5670f34c8b5098346c6580553694e7fdedf6bc5446dcc2388f44d13783d02dab,7621
   - yaml-config-0.4.0@sha256:ed0c2f343d0ef32fe1941e42c0a3ec4e78befda79a65530ce161ef3374db9f40,1948
   - roman-numerals-0.5.1.5@sha256:819d04d9d442b24629dd058f6f0b02bd78e9f9ae99538bc44ca448f1cb2b7b01,1208
-  - simple-sql-parser-0.4.4
+  - simple-sql-parser-0.6.0
   - SpreadsheetML-0.1@sha256:58aec77fb2d79779c6a1a4c2101526db0947dc558c064a46598cdde5745bfa74,1362
   #  - salve-1.0.11 # TODO Why was this required??
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,20 +12,15 @@ packages:
 extra-deps:
   - pandoc-crossref-0.3.12.2@sha256:5670f34c8b5098346c6580553694e7fdedf6bc5446dcc2388f44d13783d02dab,7621
   - yaml-config-0.4.0@sha256:ed0c2f343d0ef32fe1941e42c0a3ec4e78befda79a65530ce161ef3374db9f40,1948
-#  - pandoc-crossref-0.3.12.1
   - roman-numerals-0.5.1.5@sha256:819d04d9d442b24629dd058f6f0b02bd78e9f9ae99538bc44ca448f1cb2b7b01,1208
   - simple-sql-parser-0.4.4
-#  - simple-sql-parser-0.6.0@sha256:ce8f602fa81001287deb25af7b711fc45e1cdf36ff7702edde5dee2358f19a37,5580
   - SpreadsheetML-0.1@sha256:58aec77fb2d79779c6a1a4c2101526db0947dc558c064a46598cdde5745bfa74,1362
-#  - wl-pprint-1.2.1@sha256:aea676cff4a062d7d912149d270e33f5bb0c01b68a9db46ff13b438141ff4b7c,734
-#  - yaml-config-0.4.0@sha256:575103d9fa1ef074a2b419256babaae7be5f5257f37adf3ed2601052415b2d83,1814
-#  - salve-1.0.11
-#  # extra-deps for weeder-2.1.3:
+  #  - salve-1.0.11 # TODO Why was this required??
+
+  #  # extra-deps for weeder, for it is built with the github actions (See ci2.yml):
   - weeder-2.3.0
-#  - dhall-1.37.1@sha256:447031286e8fe270b0baacd9cc5a8af340d2ae94bb53b85807bee93381ca5287,35080
-#  - generic-lens-2.0.0.0@sha256:7409fa0ce540d0bd41acf596edd1c5d0c0ab1cd1294d514cf19c5c24e8ef2550,3866
-#  - generic-lens-core-2.0.0.0@sha256:40b063c4a1399b3cdb19f2df1fae5a1a82f3313015c7c3e47fc23b8ef1b3e443,2913
-#
+  - algebraic-graphs-0.5@sha256:6eeec5ed1687ff7aa916e7bf9f02f51aaabde6f314dc0b7b1a84156974d7da73,8071
+
 # Override default flag values for local packages and extra-deps
 flags:
   pandoc:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-18.18
+resolver: lts-19.5
 # resolver: nightly-2018-11-24 # temporarily no LTS. Same as pandoc-crossref.
 allow-newer: false
 # Local packages, usually specified by relative directory name
@@ -10,19 +10,22 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-  - pandoc-crossref-0.3.12.1
+  - pandoc-crossref-0.3.12.2@sha256:5670f34c8b5098346c6580553694e7fdedf6bc5446dcc2388f44d13783d02dab,7621
+  - yaml-config-0.4.0@sha256:ed0c2f343d0ef32fe1941e42c0a3ec4e78befda79a65530ce161ef3374db9f40,1948
+#  - pandoc-crossref-0.3.12.1
   - roman-numerals-0.5.1.5@sha256:819d04d9d442b24629dd058f6f0b02bd78e9f9ae99538bc44ca448f1cb2b7b01,1208
   - simple-sql-parser-0.4.4
+#  - simple-sql-parser-0.6.0@sha256:ce8f602fa81001287deb25af7b711fc45e1cdf36ff7702edde5dee2358f19a37,5580
   - SpreadsheetML-0.1@sha256:58aec77fb2d79779c6a1a4c2101526db0947dc558c064a46598cdde5745bfa74,1362
-  - wl-pprint-1.2.1@sha256:aea676cff4a062d7d912149d270e33f5bb0c01b68a9db46ff13b438141ff4b7c,734
-  - yaml-config-0.4.0@sha256:575103d9fa1ef074a2b419256babaae7be5f5257f37adf3ed2601052415b2d83,1814
-  - salve-1.0.11
-  # extra-deps for weeder-2.1.3:
-  - weeder-2.1.3
-  - dhall-1.37.1@sha256:447031286e8fe270b0baacd9cc5a8af340d2ae94bb53b85807bee93381ca5287,35080
-  - generic-lens-2.0.0.0@sha256:7409fa0ce540d0bd41acf596edd1c5d0c0ab1cd1294d514cf19c5c24e8ef2550,3866
-  - generic-lens-core-2.0.0.0@sha256:40b063c4a1399b3cdb19f2df1fae5a1a82f3313015c7c3e47fc23b8ef1b3e443,2913
-
+#  - wl-pprint-1.2.1@sha256:aea676cff4a062d7d912149d270e33f5bb0c01b68a9db46ff13b438141ff4b7c,734
+#  - yaml-config-0.4.0@sha256:575103d9fa1ef074a2b419256babaae7be5f5257f37adf3ed2601052415b2d83,1814
+#  - salve-1.0.11
+#  # extra-deps for weeder-2.1.3:
+  - weeder-2.3.0
+#  - dhall-1.37.1@sha256:447031286e8fe270b0baacd9cc5a8af340d2ae94bb53b85807bee93381ca5287,35080
+#  - generic-lens-2.0.0.0@sha256:7409fa0ce540d0bd41acf596edd1c5d0c0ab1cd1294d514cf19c5c24e8ef2550,3866
+#  - generic-lens-core-2.0.0.0@sha256:40b063c4a1399b3cdb19f2df1fae5a1a82f3313015c7c3e47fc23b8ef1b3e443,2913
+#
 # Override default flag values for local packages and extra-deps
 flags:
   pandoc:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -26,12 +26,12 @@ packages:
   original:
     hackage: roman-numerals-0.5.1.5@sha256:819d04d9d442b24629dd058f6f0b02bd78e9f9ae99538bc44ca448f1cb2b7b01,1208
 - completed:
-    hackage: simple-sql-parser-0.4.4@sha256:9e7171247d29d8b367f452044791223840aa4587b4e844f852cf620e85c61db0,3978
+    hackage: simple-sql-parser-0.6.0@sha256:ce8f602fa81001287deb25af7b711fc45e1cdf36ff7702edde5dee2358f19a37,5580
     pantry-tree:
-      size: 1746
-      sha256: 7d2d5a45845ef3504c585ac74cb8ff8c7300658e00f79c2208cf34829b243ea1
+      size: 2752
+      sha256: cd333c976b4b12425d0eed28749884551a4595dd249cc6d6b75c34e4ce7688cc
   original:
-    hackage: simple-sql-parser-0.4.4
+    hackage: simple-sql-parser-0.6.0
 - completed:
     hackage: SpreadsheetML-0.1@sha256:58aec77fb2d79779c6a1a4c2101526db0947dc558c064a46598cdde5745bfa74,1362
     pantry-tree:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,19 @@
 
 packages:
 - completed:
-    hackage: pandoc-crossref-0.3.12.1@sha256:4d89c5c94bb4f771d3c36adede4672f97a4d3b34862ba15b4c59568524a5f55c,7621
+    hackage: pandoc-crossref-0.3.12.2@sha256:5670f34c8b5098346c6580553694e7fdedf6bc5446dcc2388f44d13783d02dab,7621
     pantry-tree:
       size: 7178
-      sha256: 5fba7d11a596f283bd1b1458b34e57699f44b0f6e54ac5016b7aa7b863634716
+      sha256: 061dc14f9378b61991f7f78ee2b0733a5c571d4ea220449717f08428c9a0e2f7
   original:
-    hackage: pandoc-crossref-0.3.12.1
+    hackage: pandoc-crossref-0.3.12.2@sha256:5670f34c8b5098346c6580553694e7fdedf6bc5446dcc2388f44d13783d02dab,7621
+- completed:
+    hackage: yaml-config-0.4.0@sha256:ed0c2f343d0ef32fe1941e42c0a3ec4e78befda79a65530ce161ef3374db9f40,1948
+    pantry-tree:
+      size: 347
+      sha256: 039dc035daf8d9b0f2c20e549b8d1e55ca728cd28c3e522a2652b21a7f831b15
+  original:
+    hackage: yaml-config-0.4.0@sha256:ed0c2f343d0ef32fe1941e42c0a3ec4e78befda79a65530ce161ef3374db9f40,1948
 - completed:
     hackage: roman-numerals-0.5.1.5@sha256:819d04d9d442b24629dd058f6f0b02bd78e9f9ae99538bc44ca448f1cb2b7b01,1208
     pantry-tree:
@@ -33,57 +40,15 @@ packages:
   original:
     hackage: SpreadsheetML-0.1@sha256:58aec77fb2d79779c6a1a4c2101526db0947dc558c064a46598cdde5745bfa74,1362
 - completed:
-    hackage: wl-pprint-1.2.1@sha256:aea676cff4a062d7d912149d270e33f5bb0c01b68a9db46ff13b438141ff4b7c,734
+    hackage: weeder-2.3.0@sha256:b4c9030765615b209ae04634726a8f328476fa9999ff087984866e7305745d52,1934
     pantry-tree:
-      size: 221
-      sha256: 750b375c6fc33400551f9e32e26e41844c372270a9bc3571e912fa36df7c6d4f
+      size: 439
+      sha256: 1bfa016810776bccb93659b7615bd3d32db30b96371cda3ce720d77e1c491c26
   original:
-    hackage: wl-pprint-1.2.1@sha256:aea676cff4a062d7d912149d270e33f5bb0c01b68a9db46ff13b438141ff4b7c,734
-- completed:
-    hackage: yaml-config-0.4.0@sha256:575103d9fa1ef074a2b419256babaae7be5f5257f37adf3ed2601052415b2d83,1814
-    pantry-tree:
-      size: 347
-      sha256: 504d63293d50f9949a1130abcaf1885f10df61a658cba854fb704521ba797c91
-  original:
-    hackage: yaml-config-0.4.0@sha256:575103d9fa1ef074a2b419256babaae7be5f5257f37adf3ed2601052415b2d83,1814
-- completed:
-    hackage: salve-1.0.11@sha256:4a40542345aece926e9571621459e28f956e30da22163571c6d3ab5a934e07b7,1050
-    pantry-tree:
-      size: 350
-      sha256: 67b0215716ae7652da96f6846de5c845787a4e3e8cb90da8cd523e3a81c4b66d
-  original:
-    hackage: salve-1.0.11
-- completed:
-    hackage: weeder-2.1.3@sha256:db1e3fc56cd4d75bd61f0ebe2af69356cb0e6e3556628365621d5402c4d8acd0,2209
-    pantry-tree:
-      size: 438
-      sha256: f5a227042d770ea9e50e89e7447b14f9db36bfa29ecec3ea4a446271e2bb6e7c
-  original:
-    hackage: weeder-2.1.3
-- completed:
-    hackage: dhall-1.37.1@sha256:447031286e8fe270b0baacd9cc5a8af340d2ae94bb53b85807bee93381ca5287,35080
-    pantry-tree:
-      size: 305799
-      sha256: 623de5587e614ace2b6e2f908ccd4b4eec26db9cf29de45874bed8c0bdef2db8
-  original:
-    hackage: dhall-1.37.1@sha256:447031286e8fe270b0baacd9cc5a8af340d2ae94bb53b85807bee93381ca5287,35080
-- completed:
-    hackage: generic-lens-2.0.0.0@sha256:7409fa0ce540d0bd41acf596edd1c5d0c0ab1cd1294d514cf19c5c24e8ef2550,3866
-    pantry-tree:
-      size: 2470
-      sha256: 46ba160f0efc9c805eac6666f298f48dda899834b68c860f63641ce1f82db737
-  original:
-    hackage: generic-lens-2.0.0.0@sha256:7409fa0ce540d0bd41acf596edd1c5d0c0ab1cd1294d514cf19c5c24e8ef2550,3866
-- completed:
-    hackage: generic-lens-core-2.0.0.0@sha256:40b063c4a1399b3cdb19f2df1fae5a1a82f3313015c7c3e47fc23b8ef1b3e443,2913
-    pantry-tree:
-      size: 2201
-      sha256: 73f91636570c0e96044f655402ccbf6adba78d3a93f8d9ee97f3115bae096536
-  original:
-    hackage: generic-lens-core-2.0.0.0@sha256:40b063c4a1399b3cdb19f2df1fae5a1a82f3313015c7c3e47fc23b8ef1b3e443,2913
+    hackage: weeder-2.3.0
 snapshots:
 - completed:
-    size: 586296
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
-    sha256: 63539429076b7ebbab6daa7656cfb079393bf644971156dc349d7c0453694ac2
-  original: lts-18.18
+    size: 619093
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/5.yaml
+    sha256: b936d27d647a31a8834d3efec126e2a07dee9c9bd6dd401d9bdac77e7b278f1e
+  original: lts-19.5

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -46,6 +46,13 @@ packages:
       sha256: 1bfa016810776bccb93659b7615bd3d32db30b96371cda3ce720d77e1c491c26
   original:
     hackage: weeder-2.3.0
+- completed:
+    hackage: algebraic-graphs-0.5@sha256:6eeec5ed1687ff7aa916e7bf9f02f51aaabde6f314dc0b7b1a84156974d7da73,8071
+    pantry-tree:
+      size: 4128
+      sha256: cca4a0348bb126506cacd8436948a68aad62e75d45df8c71f4090a00e69b45ee
+  original:
+    hackage: algebraic-graphs-0.5@sha256:6eeec5ed1687ff7aa916e7bf9f02f51aaabde6f314dc0b7b1a84156974d7da73,8071
 snapshots:
 - completed:
     size: 619093


### PR DESCRIPTION
Upgrade to use GHC 9.0.2 . 
The upgrade itself is ready, however I do not recommend tot switch to it right now, because the haskell-language-server doesn't currently support it out of the box. Let's wait for that to happen. (See https://github.com/haskell/vscode-haskell#supported-ghc-versions). Only merge this PR when GHC 9.0.2 is supported. 
The state of support can be monitored here: https://github.com/haskell/haskell-language-server/issues/297