### PR TITLE
minor, but still a bug.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,7 @@
 ﻿# Release notes of Ampersand
  
 ## Unreleased changes
+* [Issue #1313](https://github.com/AmpersandTarski/Ampersand/issues/1313) Fixed a minor bug in the Archi analyser.
 * Improve the usability of the MetaModel.adl file, which is output of `ampersand data-analysis`.
 * [Issue #987](https://github.com/AmpersandTarski/Ampersand/issues/987) Fixed a bug in the Excel parser.
 * refactoring Archimate parser

--- a/src/Ampersand/Input/Archi/ArchiAnalyze.hs
+++ b/src/Ampersand/Input/Archi/ArchiAnalyze.hs
@@ -149,7 +149,7 @@ mkArchiContext [archiRepo] pops =
           isRelevant ag = dec_nm (grainRel ag) `L.notElem` ["inside", "inView"]
           inView :: ArchiGrain -> Bool
           inView ag = case archiViewname ag of
-            Nothing -> fatal "Jammer dan"
+            Nothing -> False
             Just nm -> nm == viewName vw
           participatingRel :: ArchiGrain -> Bool
           participatingRel ag = (pSrc . dec_sign . grainRel) ag `L.notElem` map PCpt ["Relationship", "Property", "View"]


### PR DESCRIPTION
# What happened
I ran an example Archimate file with the refactored Archi parser. I got the fatal error message "Jammer dan".

# Diagnosis
It turned out that the root node in Archi does not participate in any view. The error message "Jammer dan" was given by the function `vwAts` because we (erroneously) assumed that every node participates in a view. So I fixed this error by letting this function ignore all Archi nodes that are not in any view.