### PR TITLE
Options to limit generated visuals

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,7 @@
 ﻿# Release notes of Ampersand
 
 ## Unreleased
+- [Issue #1583](https://github.com/AmpersandTarski/Ampersand/issues/1583) Enable user to limit generation of visuals
 - [Issue #1582](https://github.com/AmpersandTarski/Ampersand/issues/1582) Take rdfs:domain and rdfs:range into account in turtle parser. Also add meanings
 
 ## v5.4.9

--- a/src/Ampersand/Graphic/Graphics.hs
+++ b/src/Ampersand/Graphic/Graphics.hs
@@ -134,6 +134,7 @@ makePicture env fSpec pr =
       Picture
         { pType = pr,
           pictureFileName = toBaseFileName "TechnicalDataModel",
+          -- PTTechnicalDataModel is not included in datamodels-only mode by design.
           forDataModelsOnlySwitch = False,
           scale = scale',
           dotContent = ClassDiagram $ tdAnalysis fSpec,

--- a/src/Ampersand/Graphic/Graphics.hs
+++ b/src/Ampersand/Graphic/Graphics.hs
@@ -53,7 +53,8 @@ data Picture = Picture
     -- | the name of the program to use  ("dot" or "neato" or "fdp" or "Sfdp")
     dotProgName :: !GraphvizCommand,
     -- | a human readable name of this picture
-    caption :: !Text
+    caption :: !Text,
+    visualFocus :: !FocusOfVisual -- the focus of this picture, used to determine whether it should be generated
   }
 
 instance Named PictureTyp where -- for displaying a fatal error
@@ -91,7 +92,8 @@ makePicture env fSpec pr =
           caption =
             case outputLang' of
               English -> "Classification of " <> fullName fSpec
-              Dutch -> "Classificatie van " <> fullName fSpec
+              Dutch -> "Classificatie van " <> fullName fSpec,
+          visualFocus = VContext
         }
     PTLogicalDataModelOfContext grouped ->
       Picture
@@ -111,33 +113,36 @@ makePicture env fSpec pr =
           caption =
             case outputLang' of
               English -> "Logical data model of " <> fullName fSpec
-              Dutch -> "Logisch gegevensmodel van " <> fullName fSpec
+              Dutch -> "Logisch gegevensmodel van " <> fullName fSpec,
+          visualFocus = VContext
         }
     PTLogicalDataModelOfPattern pat ->
       Picture
         { pType = pr,
           pictureFileName = toBaseFileName $ "LogicalDataModel-" <> (text1ToText . urlEncodedName . name) pat,
-          forDataModelsOnlySwitch = True,
+          forDataModelsOnlySwitch = False,
           scale = scale',
           dotContent = ClassDiagram . cdAnalysis False env fSpec $ pat,
           dotProgName = Dot,
           caption =
             case outputLang' of
               English -> "Logical data model of " <> fullName pat
-              Dutch -> "Logisch gegevensmodel van " <> fullName pat
+              Dutch -> "Logisch gegevensmodel van " <> fullName pat,
+          visualFocus = VPattern
         }
     PTTechnicalDataModel ->
       Picture
         { pType = pr,
           pictureFileName = toBaseFileName "TechnicalDataModel",
-          forDataModelsOnlySwitch = True,
+          forDataModelsOnlySwitch = False,
           scale = scale',
           dotContent = ClassDiagram $ tdAnalysis fSpec,
           dotProgName = Dot,
           caption =
             case outputLang' of
               English -> "Technical data model of " <> fullName fSpec
-              Dutch -> "Technisch gegevensmodel van " <> fullName fSpec
+              Dutch -> "Technisch gegevensmodel van " <> fullName fSpec,
+          visualFocus = VContext
         }
     PTConceptualModelOfConcept cpt ->
       Picture
@@ -150,7 +155,8 @@ makePicture env fSpec pr =
           caption =
             case outputLang' of
               English -> "Concept diagram of " <> fullName cpt
-              Dutch -> "Conceptueel diagram van " <> fullName cpt
+              Dutch -> "Conceptueel diagram van " <> fullName cpt,
+          visualFocus = VConcept
         }
     PTConceptualModelOfRelationsInPattern pat ->
       Picture
@@ -163,7 +169,8 @@ makePicture env fSpec pr =
           caption =
             case outputLang' of
               English -> "Concept diagram of relations in " <> fullName pat
-              Dutch -> "Conceptueel diagram van relaties in " <> fullName pat
+              Dutch -> "Conceptueel diagram van relaties in " <> fullName pat,
+          visualFocus = VRelation
         }
     PTConceptualModelOfRulesInPattern pat ->
       Picture
@@ -176,7 +183,8 @@ makePicture env fSpec pr =
           caption =
             case outputLang' of
               English -> "Concept diagram of the rules in " <> fullName pat
-              Dutch -> "Conceptueel diagram van regels in" <> fullName pat
+              Dutch -> "Conceptueel diagram van regels in" <> fullName pat,
+          visualFocus = VPattern
         }
     PTConceptualModelOfRule rul ->
       Picture
@@ -189,7 +197,8 @@ makePicture env fSpec pr =
           caption =
             case outputLang' of
               English -> "Concept diagram of rule " <> fullName rul
-              Dutch -> "Conceptueel diagram van regel " <> fullName rul
+              Dutch -> "Conceptueel diagram van regel " <> fullName rul,
+          visualFocus = VRule
         }
   where
     outputLang' :: Lang
@@ -280,6 +289,7 @@ conceptualStructure fSpec pr =
     isaEdges cpts = Set.fromList [(s, g) | (s, g) <- gs, g `elem` cpts, s `elem` cpts]
     gs = fsisa fSpec
 
+-- write the visual in all the formats requested
 writePicture ::
   (HasDirOutput env, HasBlackWhite env, HasDocumentOpts env, HasLogFunc env) =>
   Picture ->
@@ -289,15 +299,11 @@ writePicture pict = do
   graphvizIsInstalled <- liftIO isGraphvizInstalled
   unless graphvizIsInstalled $ exitWith GraphVizNotInstalled
   dirOutput <- view dirOutputL
+  visualsOutputFormats <- view visualsOutputFormatsL
   let imagePathRelativeToCurrentDir = dirOutput </> imagePathRelativeToDirOutput env pict
   logDebug $ "imagePathRelativeToCurrentDir = " <> display (T.pack imagePathRelativeToCurrentDir)
   liftIO $ createDirectoryIfMissing True (takeDirectory imagePathRelativeToCurrentDir)
-  writeDot imagePathRelativeToCurrentDir Canon -- To obtain the Graphviz source code of the images
-  --  writeDot imagePathRelativeToCurrentDir DotOutput --Reproduces the input along with layout information.
-  writeDot imagePathRelativeToCurrentDir Png -- handy format to include in github comments/issues
-  -- writeDot imagePathRelativeToCurrentDir Svg   -- format that is used when docx docs are being generated.
-  writeDot imagePathRelativeToCurrentDir Pdf -- format that is used when docx docs are being generated.
-  -- writePdf imagePathRelativeToCurrentDir Eps   -- .eps file that is postprocessed to a .pdf file
+  mapM_ (writeDot imagePathRelativeToCurrentDir) (visualsOutputFormat2graphvizOutput <$> Set.toList visualsOutputFormats)
   where
     writeDot ::
       (HasBlackWhite env, HasLogFunc env) =>

--- a/src/Ampersand/Misc/HasClasses.hs
+++ b/src/Ampersand/Misc/HasClasses.hs
@@ -6,6 +6,7 @@ module Ampersand.Misc.HasClasses where
 
 import Ampersand.Basics
 import Ampersand.Misc.Defaults (defaultDirPrototype)
+import Data.GraphViz (GraphvizOutput (..))
 import RIO.FilePath
 import qualified RIO.List as L
 import qualified RIO.NonEmpty as NE
@@ -176,6 +177,10 @@ class (HasOutputLanguage a) => HasDocumentOpts a where
   genLegalRefsL = documentOptsL . lens xgenLegalRefs (\x y -> x {xgenLegalRefs = y})
   genGraphicsL :: Lens' a Bool -- Generate graphics. Useful for generating text and graphics separately.
   genGraphicsL = documentOptsL . lens xgenGraphics (\x y -> x {xgenGraphics = y})
+  visualsOutputFormatsL :: Lens' a (Set VisualsOutputFormat)
+  visualsOutputFormatsL = documentOptsL . lens xvisualsOutputFormats (\x y -> x {xvisualsOutputFormats = y})
+  focusOfVisualsL :: Lens' a (Set FocusOfVisual)
+  focusOfVisualsL = documentOptsL . lens xfocusOfVisuals (\x y -> x {xfocusOfVisuals = y})
   uniEdgesL :: Lens' a Bool -- Draw edges for univalent and/or injective relations in the LDM.
   uniEdgesL = documentOptsL . lens xuniEdges (\x y -> x {xuniEdges = y})
   genTextL :: Lens' a Bool -- Generate text. Useful for generating text and graphics separately.
@@ -368,6 +373,52 @@ instance HasOptions ProtoOpts where
            ("--[no-]metamodel", tshow $ xgenerateMetamodel opts)
          ]
 
+-- | Known outputformats for Ampersand.
+data VisualsOutputFormat
+  = VBmp
+  | VCanon
+  | VJpeg
+  | VPdf
+  | VPlain
+  | VPng
+  | VSvg
+  | VTiff
+  deriving (Eq, Ord, Enum, Bounded)
+
+-- | Show is used to represent the file extension of the output format.
+instance Show VisualsOutputFormat where
+  show :: VisualsOutputFormat -> String
+  show VBmp = "bmp"
+  show VCanon = "gv"
+  show VJpeg = "jpg"
+  show VPdf = "pdf"
+  show VPlain = "txt"
+  show VPng = "png"
+  show VSvg = "svg"
+  show VTiff = "tif"
+
+visualsOutputFormat2graphvizOutput :: VisualsOutputFormat -> GraphvizOutput
+visualsOutputFormat2graphvizOutput VBmp = Bmp
+visualsOutputFormat2graphvizOutput VCanon = Canon
+visualsOutputFormat2graphvizOutput VJpeg = Jpeg
+visualsOutputFormat2graphvizOutput VPdf = Pdf
+visualsOutputFormat2graphvizOutput VPlain = Plain
+visualsOutputFormat2graphvizOutput VPng = Png
+visualsOutputFormat2graphvizOutput VSvg = Svg
+visualsOutputFormat2graphvizOutput VTiff = Tiff
+
+-- | A type to denote the focus of generated visuals.
+data FocusOfVisual = VContext | VPattern | VRule | VRelation | VConcept
+  deriving (Eq, Ord, Enum, Bounded)
+
+instance Show FocusOfVisual where
+  show :: FocusOfVisual -> String
+  show VContext = "context"
+  show VPattern = "pattern"
+  show VRule = "rule"
+  show VRelation = "relation"
+  show VConcept = "concept"
+
 -- | Options for @ampersand documentation@.
 data DocOpts = DocOpts
   { -- | avoid coloring conventions to facilitate readable pictures in black and white.
@@ -378,6 +429,10 @@ data DocOpts = DocOpts
     xgenDatamodelImagesOnly :: !Bool,
     -- | enable/disable generation of graphics. Used to generate text and graphics in separation.
     xgenGraphics :: !Bool,
+    -- | GraphvizOutput types that are required to be generated when only graphics are generated.
+    xvisualsOutputFormats :: !(Set VisualsOutputFormat),
+    -- | FocusOfVisuals types that should be generated.
+    xfocusOfVisuals :: !(Set FocusOfVisual),
     -- | draw edges for univalent and/or injective relations in the LDM.
     xuniEdges :: !Bool,
     -- | enable/disable generation of text. Used to generate text and graphics in separation.

--- a/src/Ampersand/Options/DocOptsParser.hs
+++ b/src/Ampersand/Options/DocOptsParser.hs
@@ -147,7 +147,7 @@ docOptsParser =
       boolFlags
         True
         "text"
-        "generation of the document file, which contains the text and graphics."
+        "generate the document file, which contains the text and graphics."
         mempty
     visualsOutputFormatsP :: Parser [VisualsOutputFormat]
     visualsOutputFormatsP =
@@ -217,7 +217,7 @@ docOptsParser =
               $ "Invalid focus: "
               <> T.unpack s
               <> ". Valid choices are: "
-              <> (L.intercalate ", " . map show $ focuses)
+              <> (L.intercalate "," . map show $ focuses)
 
         focuses :: [FocusOfVisual]
         focuses = [minBound ..]

--- a/src/Ampersand/Options/DocOptsParser.hs
+++ b/src/Ampersand/Options/DocOptsParser.hs
@@ -9,7 +9,9 @@ import Ampersand.Options.Utils
 import Options.Applicative
 import Options.Applicative.Builder.Extra
 import qualified RIO.List as L
+import qualified RIO.Set as Set
 import qualified RIO.Text as T
+import qualified RIO.Text.Partial as Partial
 
 -- | Command-line parser for the document command.
 docOptsParser ::
@@ -20,6 +22,8 @@ docOptsParser =
     <*> chaptersP
     <*> datamodelOnlyP
     <*> genGraphicsP
+    <*> (Set.fromList <$> visualsOutputFormatsP)
+    <*> (Set.fromList <$> focusOfVisualsP)
     <*> uniEdgesP
     <*> genTextP
     <*> fSpecFormatP
@@ -143,8 +147,80 @@ docOptsParser =
       boolFlags
         True
         "text"
-        "generation the document file."
+        "generation of the document file, which contains the text and graphics."
         mempty
+    visualsOutputFormatsP :: Parser [VisualsOutputFormat]
+    visualsOutputFormatsP =
+      option
+        parseList'
+        ( long "graphicFormats"
+            <> metavar "FORMAT1,FORMAT2,..."
+            <> value [VCanon, VPng]
+            <> showDefault
+            <> completeWith (map (T.unpack . tshow) visualFormats)
+            <> help
+              ( "Comma-separated list of graphic formats to generate."
+                  <> "   Possible formats are: "
+                  <> (L.intercalate "," . map show $ visualFormats)
+                  <> ". Note that there must not be any spaces in the list."
+              )
+        )
+      where
+        parseList' :: ReadM [VisualsOutputFormat]
+        parseList' =
+          eitherReader
+            ( \arg -> do
+                let parts = Partial.splitOn "," (T.pack arg)
+                mapM visualsOutputFormatP parts
+            )
+        visualsOutputFormatP :: Text -> Either String VisualsOutputFormat
+        visualsOutputFormatP s = case filter ((==) (T.toLower s) . T.toLower . tshow) [minBound ..] of
+          [x] -> Right x
+          _ ->
+            Left
+              $ "Invalid visual output format: "
+              <> T.unpack s
+              <> ". Valid formats: "
+              <> (L.intercalate "," . map show $ visualFormats)
+
+        visualFormats :: [VisualsOutputFormat]
+        visualFormats = [minBound ..]
+    focusOfVisualsP :: Parser [FocusOfVisual]
+    focusOfVisualsP =
+      option
+        parseList'
+        ( long "focus-of-visuals"
+            <> metavar "FOCUS1,FOCUS2,..."
+            <> value [VContext, VPattern]
+            <> showDefault
+            <> completeWith (map (T.unpack . tshow) focuses)
+            <> help
+              ( "Comma-separated list of things you'd like the graphics to focus on."
+                  <> "   Possible choices are: "
+                  <> (T.unpack . T.intercalate "," . map tshow $ focuses)
+                  <> ". Note that there must not be any spaces in the list."
+              )
+        )
+      where
+        parseList' :: ReadM [FocusOfVisual]
+        parseList' =
+          eitherReader
+            ( \arg -> do
+                let parts = Partial.splitOn "," (T.pack arg)
+                mapM focusOfVisualP parts
+            )
+        focusOfVisualP :: Text -> Either String FocusOfVisual
+        focusOfVisualP s = case filter ((==) (T.toLower s) . T.toLower . tshow) [minBound ..] of
+          [x] -> Right x
+          _ ->
+            Left
+              $ "Invalid focus: "
+              <> T.unpack s
+              <> ". Valid choices are: "
+              <> (L.intercalate ", " . map show $ focuses)
+
+        focuses :: [FocusOfVisual]
+        focuses = [minBound ..]
 
     blackWhiteP :: Parser Bool
     blackWhiteP =


### PR DESCRIPTION
new and modified options:

~~~
  --datamodelOnly          Only generate datamodel images. This implies
                           --no-text
  --graphicFormats FORMAT1,FORMAT2,...
                           Comma-separated list of graphic formats to generate.
                           Possible formats are: bmp,gv,jpg,pdf,txt,png,svg,tif.
                           Note that there must not be any spaces in the list.
                           (default: [gv,png])
  --focus-of-visuals FOCUS1,FOCUS2,...
                           Comma-separated list of things you'd like the
                           graphics to focus on. Possible choices are:
                           context,pattern,rule,relation,concept. Note that
                           there must not be any spaces in the list.
                           (default: [context,pattern])
~~~
