### PR TITLE
Drop the macOS build from CI and releases

### DIFF
--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -52,24 +52,6 @@ jobs:
           upgrade-stack: false
           cache-save-always: true
 
-  build-and-test-macOS-14:
-    name: Build and test on macos-14  🏗 🧪
-    runs-on: macos-14
-    steps:
-      - name: Checkout project contents 📡
-        uses: actions/checkout@v4
-      - name: Set up Mariadb 🧰
-        uses: shogo82148/actions-setup-mysql@v1
-        with:
-          mysql-version: "mariadb-11.5"
-      # See issue https://github.com/freckle/stack-action/issues/80 for why we need to install stack and php as well
-      ## run: curl -sSL https://get.haskellstack.org/ | sh
-      # - run: brew install php
-      - name: Build and test  🏗 🧪
-        uses: freckle/stack-action@v5
-        with:
-          stack-build-arguments: "--copy-bins --flag ampersand:buildAll"
-          test: false #Temporarily disable test because of bug in MariaDB with macOS. See https://jira.mariadb.org/browse/MDEV-35173
   build-and-test-windows:
     name: Build and test on windows-2022 🏗 🧪
     runs-on: windows-2022

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # This workflow triggers on a new release that is being created
 # It build-pushes a release image to DockerHub
-# and it attaches Linux, MacOS and Windows binary files to the release
+# and it attaches Linux and Windows binary files to the release
 name: Release
 on:
   release:
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Upload macOS artifact
+      - name: Upload ReleaseNotes
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -67,7 +67,6 @@ jobs:
     needs:
       [
         build-without-test-ubuntu,
-        build-without-test-macOS,
         build-without-test-windows,
       ]
     runs-on: ubuntu-22.04
@@ -91,18 +90,6 @@ jobs:
           files: release/Linux/
           dest: release/linux-binaries-v${{ steps.get-version.outputs.version }}.zip
 
-      - name: Download artifacts (macOS)
-        uses: actions/download-artifact@v4
-        with:
-          name: macOS-binaries
-          path: release/macOS
-
-      - name: zip the binaries (macOS)
-        uses: papeloto/action-zip@v1
-        with:
-          files: release/macOS/
-          dest: release/macOS-binaries-v${{ steps.get-version.outputs.version }}.zip
-
       - name: Download artifacts (Windows)
         uses: actions/download-artifact@v4
         with:
@@ -123,16 +110,6 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_name: ampersand-${{ steps.get-version.outputs.version }}-Linux-binaries.zip
           asset_path: release/linux-binaries-v${{ steps.get-version.outputs.version }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload macOS artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_name: ampersand-${{ steps.get-version.outputs.version }}-macOS-binaries.zip
-          asset_path: release/macOS-binaries-v${{ steps.get-version.outputs.version }}.zip
           asset_content_type: application/zip
 
       - name: Upload Windows artifact
@@ -166,31 +143,6 @@ jobs:
         with:
           name: Linux-binaries
           path: /home/runner/.local/bin/*
-
-  build-without-test-macOS:
-    name: Build without test on macos-13  🏗 🧪
-    runs-on: macos-13
-    steps:
-      - name: Checkout project contents 📡
-        uses: actions/checkout@v4
-      - name: Set up Mariadb 🧰
-        uses: shogo82148/actions-setup-mysql@v1
-        with:
-          mysql-version: "mariadb-11.5"
-      # See issue https://github.com/freckle/stack-action/issues/80 for why we need to install stack and php as well
-      ## - run: curl -sSL https://get.haskellstack.org/ | sh
-      - run: brew install php
-      - name: Build without test  🏗 🧪
-        uses: freckle/stack-action@v5
-        with:
-          stack-build-arguments: "--copy-bins --flag ampersand:buildAll"
-          upgrade-stack: false
-          test: false
-      - name: Upload artifacts (macOS)
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS-binaries
-          path: /Users/runner/.local/bin/*
 
   build-without-test-windows:
     name: build without test on windows-2022 🏗 🧪

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 ﻿# Release notes of Ampersand
 
+## Unreleased
+- CI/release: drop the macOS build entirely. GitHub deprecated the macos-13 runner and the Apple-Silicon (macos-14) build was failing; since Ampersand runs under Linux/Docker on macOS anyway, the native macOS binary is no longer built or attached to releases. Prebuilt binaries are now Linux and Windows; on macOS, use Docker or build from source.
+
+
 ## v5.5.6
 - [#1613](https://github.com/AmpersandTarski/Ampersand/issues/1613) Harvest owl:DatatypeProperty from turtle files
 


### PR DESCRIPTION
GitHub deprecated macos-13 and the macos-14 build failed. Ampersand runs under Linux/Docker on macOS, so the native macOS binary is dropped from ci2.yml and release.yml. Prebuilt binaries are now Linux and Windows.