### PR TITLE
CI: build only when the build kernel changes

### DIFF
--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -4,8 +4,27 @@ on:
   push:
     branches:
       - "**" # Only trigger on branches (i.e. not tags, ..)
-    paths-ignore:
-      - "docs/**" # If only documentation changes, no need to build.
+    paths:
+      # Build kernel: only changes to what the compiler build actually
+      # consumes should trigger a (re)build. Update this list only when you
+      # change what goes into the build. Everything else (docs, memorybank,
+      # ReleaseNotes.md, READMEs, the workflow files themselves) is ignored
+      # on purpose, so non-build changes do not spin up the Haskell build.
+      - "src/**"
+      - "app/**"
+      - "AmpersandData/**"      # bundled into the binary (extra-source-files)
+      - "outputTemplates/**"    # bundled into the binary (extra-source-files)
+      - "testing/**"            # test-suite inputs (extra-source-files)
+      - "package.yaml"
+      - "ampersand.cabal"
+      - "stack.yaml"
+      - "stack.yaml.lock"
+      - "Setup.hs"
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".hlint.yaml"
+      - "weeder.dhall"
+      - "hie.yaml"
 jobs:
   build-and-test-docker:
     name: Build with Docker

--- a/.github/workflows/codeQuality.yml
+++ b/.github/workflows/codeQuality.yml
@@ -4,8 +4,27 @@ on:
   push:
     branches:
       - "**" # Only trigger on branches (i.e. not tags, ..)
-    paths-ignore:
-      - "docs/**" # If only documentation changes, no need to build.
+    paths:
+      # Build kernel: only changes to what the compiler build actually
+      # consumes should trigger a (re)build. Update this list only when you
+      # change what goes into the build. Everything else (docs, memorybank,
+      # ReleaseNotes.md, READMEs, the workflow files themselves) is ignored
+      # on purpose, so non-build changes do not spin up the Haskell build.
+      - "src/**"
+      - "app/**"
+      - "AmpersandData/**"      # bundled into the binary (extra-source-files)
+      - "outputTemplates/**"    # bundled into the binary (extra-source-files)
+      - "testing/**"            # test-suite inputs (extra-source-files)
+      - "package.yaml"
+      - "ampersand.cabal"
+      - "stack.yaml"
+      - "stack.yaml.lock"
+      - "Setup.hs"
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".hlint.yaml"
+      - "weeder.dhall"
+      - "hie.yaml"
 jobs:
   hlint:
     name: Hlint - Check for code sanity

--- a/.github/workflows/ormolu-formatting-code.yml
+++ b/.github/workflows/ormolu-formatting-code.yml
@@ -8,8 +8,27 @@ on:
     # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
     # as defined in the (optional) "skipLabels" property.
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-    paths-ignore:
-      - "docs/**" # If only documentation changes, no need to build.
+    paths:
+      # Build kernel: only changes to what the compiler build actually
+      # consumes should trigger a (re)build. Update this list only when you
+      # change what goes into the build. Everything else (docs, memorybank,
+      # ReleaseNotes.md, READMEs, the workflow files themselves) is ignored
+      # on purpose, so non-build changes do not spin up the Haskell build.
+      - "src/**"
+      - "app/**"
+      - "AmpersandData/**"      # bundled into the binary (extra-source-files)
+      - "outputTemplates/**"    # bundled into the binary (extra-source-files)
+      - "testing/**"            # test-suite inputs (extra-source-files)
+      - "package.yaml"
+      - "ampersand.cabal"
+      - "stack.yaml"
+      - "stack.yaml.lock"
+      - "Setup.hs"
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".hlint.yaml"
+      - "weeder.dhall"
+      - "hie.yaml"
 
 jobs:
   # Enforces the use of ormolu formatting of each Haskell file on every pull request

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,7 @@
 - Documentation tooling: add a CI hygiene check (`scripts/check-docs-sidebar.js`) that fails on duplicate sidebar ids, broken sidebar references, or internal scratch notes published outside a `_`-prefixed path.
 - Add `CLAUDE.md` with repository conventions (release-notes enforcement, docs publishing branch, internal-notes convention).
 - CI/release: drop the macOS build entirely. GitHub deprecated the macos-13 runner and the Apple-Silicon (macos-14) build was failing; since Ampersand runs under Linux/Docker on macOS anyway, the native macOS binary is no longer built or attached to releases. Prebuilt binaries are now Linux and Windows; on macOS, use Docker or build from source.
+- CI: trigger the build/quality/format workflows from an explicit build-kernel allowlist (`src`, `app`, `AmpersandData`, `outputTemplates`, `testing`, the package/stack files, `Dockerfile`, lint configs) instead of `paths-ignore: docs/**`. Non-build changes (docs, ReleaseNotes, READMEs, workflow files) no longer start a build.
 
 ## v5.5.6
 - [#1613](https://github.com/AmpersandTarski/Ampersand/issues/1613) Harvest owl:DatatypeProperty from turtle files


### PR DESCRIPTION
Replace paths-ignore: docs/** with an explicit build-kernel allowlist in the build, quality and formatting workflows.