### PR TITLE
test: empty-BOX interface regression test (issue #1533)

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,6 @@
 ﻿# Release notes of Ampersand
+## Unreleased
+- Added a regression test for [issue #1533](https://github.com/AmpersandTarski/Ampersand/issues/1533) (empty-`BOX` interface): `testing/Travis/testcases/Misc/Issue1533.adl` checks that a script with an empty `BOX []` interface compiles without type or population errors.
 ## v5.6.1
 - **Object identities are kept unique within 254 characters**: an OBJECT atom identity longer than 254 characters is now deterministically shortened to `<first 243 chars>_<10 hex chars of sha1(id)>`. This applies to every OBJECT atom (script population, `INCLUDE`d spreadsheets, and the runtime importers), so generated population never overflows the `VARCHAR(255)` database column and distinct identities stay distinct. The algorithm is byte-for-byte identical to the runtime prototype framework's `Atom::setId`, so a compile-time-imported object atom and the same atom created at runtime map to the same database row. A known-answer test pins the shared vector, and a `validate` regression test (`testing/Travis/testcases/Parsing/xlsxLongObjectId`) checks the spreadsheet importer end-to-end.
 ## v5.6.0

--- a/testing/Travis/testcases/Misc/Issue1533.adl
+++ b/testing/Travis/testcases/Misc/Issue1533.adl
@@ -1,0 +1,10 @@
+CONTEXT Issue1533
+
+-- This test succeeds if a prototype is generated and the interface `Landenlijst` displays as an empty box.
+-- I'm not sure whether this test is in the right directory.
+
+RELATION editLand[SESSION*LandCode] [UNI]
+
+INTERFACE Landenlijst : "_SESSION"[SESSION];editLand BOX []
+
+ENDCONTEXT


### PR DESCRIPTION
Re-adds the empty-`BOX []` interface test for [issue #1533](https://github.com/AmpersandTarski/Ampersand/issues/1533) onto current `main`, replacing the stale PR #1541 (15 months behind `main`, no CI run).

- `testing/Travis/testcases/Misc/Issue1533.adl` — a script with an empty `BOX []` interface; the `shouldSucceed`/Misc harness verifies it compiles without type or population errors. Verified locally: *"no type errors and no population errors"*.
- The companion `issue1537.adl` from #1541 is intentionally **dropped**: its intended behaviour (CRUD with technical types) cannot be verified by the static harness — it needs a Gatling-type runtime test — and `main` already carries a separate test for #1537.

Closes #1541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)