### PR TITLE
PrototypeContext: a session has at most one active role

### DIFF
--- a/AmpersandData/PrototypeContext/PrototypeContext.adl
+++ b/AmpersandData/PrototypeContext/PrototypeContext.adl
@@ -11,8 +11,8 @@ CONTEXT PrototypeContext IN ENGLISH
   INCLUDE "Roles.adl"
 
   RELATION PrototypeContext.sessionAllowedRoles[SESSION*PrototypeContext.Role]
-  RELATION PrototypeContext.sessionActiveRoles[SESSION*PrototypeContext.Role]
-  
+  RELATION PrototypeContext.sessionActiveRoles[SESSION*PrototypeContext.Role] [UNI] -- A session has at most ONE active role at any moment.
+
   RULE PrototypeContext.ActiveRoles LABEL "Active roles MUST be a subset of allowed roles" : -- This rule is required for the access control mechanism.
      PrototypeContext.sessionActiveRoles |- PrototypeContext.sessionAllowedRoles           -- It ensures that only allowed roles can be activated.
   


### PR DESCRIPTION
Adds `[UNI]` to `PrototypeContext.sessionActiveRoles`:

```
RELATION PrototypeContext.sessionActiveRoles[SESSION*PrototypeContext.Role] [UNI]
```

So the prototype framework enforces, at the meta-model level, that a session is coupled to **exactly one active role** at any moment. This pairs with the single-select role switcher in the framework frontend (a session activates one role at a time). Applications that need single-role per session no longer have to enforce it themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)