### PR TITLE
Release v5.9.0 — TRANSACTIONAL INTERFACE keyword (#1658)

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,6 @@
 ﻿# Release notes of Ampersand
+## Unreleased
+- **New keyword `TRANSACTIONAL INTERFACE`**: a modeller can now declare an interface as one optimistic transaction by writing `TRANSACTIONAL` in front of `INTERFACE` (or `API`). The compiler parses the keyword and records the flag as `isTransactional` in `generics/interfaces.json`, from which the prototype framework drives its buffered save/cancel edit mode (Save enabled only when all invariants hold, Cancel rolls back). Because the choice lives in the model, a transactional interface stays transactional wherever it is reused, including as a `LINKTO` sub-interface. See [issue #1658](https://github.com/AmpersandTarski/Ampersand/issues/1658) and the reference material on interfaces.
 ## v5.8.1
 - **Docker image and CI move to Ubuntu 24.04 LTS**: the `ampersandtarski/ampersand` image is now built `FROM ubuntu:24.04` (was 22.04) and every GitHub Actions workflow runs on `ubuntu-24.04`, so the released binaries and the container run on the current LTS. No functional change to the compiler.
 ## v5.8.0

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,5 @@
 ﻿# Release notes of Ampersand
-## Unreleased
+## v5.9.0
 - **New keyword `TRANSACTIONAL INTERFACE`**: a modeller can now declare an interface as one optimistic transaction by writing `TRANSACTIONAL` in front of `INTERFACE` (or `API`). The compiler parses the keyword and records the flag as `isTransactional` in `generics/interfaces.json`, from which the prototype framework drives its buffered save/cancel edit mode (Save enabled only when all invariants hold, Cancel rolls back). Because the choice lives in the model, a transactional interface stays transactional wherever it is reused, including as a `LINKTO` sub-interface. See [issue #1658](https://github.com/AmpersandTarski/Ampersand/issues/1658) and the reference material on interfaces.
 ## v5.8.1
 - **Docker image and CI move to Ubuntu 24.04 LTS**: the `ampersandtarski/ampersand` image is now built `FROM ubuntu:24.04` (was 22.04) and every GitHub Actions workflow runs on `ubuntu-24.04`, so the released binaries and the container run on the current LTS. No functional change to the compiler.

--- a/ampersand.cabal
+++ b/ampersand.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           ampersand
-version:        5.8.1
+version:        5.9.0
 synopsis:       Toolsuite for automated design of enterprise information systems.
 description:    You can define your business processes by means of rules, written in Relation Algebra.
 category:       Database Design

--- a/docs/reference-material/interfaces.md
+++ b/docs/reference-material/interfaces.md
@@ -48,11 +48,11 @@ This chapter gives the formal syntax of interfaces for the purpose of reference.
 An interface specification has the following structure. It is identical for user interfaces (`INTERFACE`) and application programming interfaces (`API`).
 
 ```
-INTERFACE <name> <forRoles>? : <term> <crud>? <view>? <subinterface>?
-API       <name> <forRoles>? : <term> <crud>? <view>? <subinterface>?
+TRANSACTIONAL? INTERFACE <name> <forRoles>? : <term> <crud>? <view>? <subinterface>?
+TRANSACTIONAL? API       <name> <forRoles>? : <term> <crud>? <view>? <subinterface>?
 ```
 
-The name of an interface must be unique within the context. The term defines the atoms to which the interface can be applied. The (optional) crud annotation constrains the possible interactions a user can do. The (optional) views determine what the interface will look like. If no view is specified, the interface will look like the screenshot above. Finally the sub-interface contains all the contents, i.e. the fields, field names and the constraints on them.
+The name of an interface must be unique within the context. The term defines the atoms to which the interface can be applied. The (optional) crud annotation constrains the possible interactions a user can do. The (optional) views determine what the interface will look like. If no view is specified, the interface will look like the screenshot above. Finally the sub-interface contains all the contents, i.e. the fields, field names and the constraints on them. The (optional) keyword `TRANSACTIONAL` marks the interface for [transactional editing](#transactional-interfaces).
 
 The hierarchy of boxes in an interface comes from the following (recursive) syntax of `<subinterface>`.
 
@@ -191,6 +191,40 @@ We have discussed the `FORM`, `TABLE`, and `TABS` layout options. Please note th
 ### Your own layout and your own widgets \(HTML and CSS\)
 
 You don't have to put up with the [Ampersand built-in layout options](./syntax-of-ampersand#layout-of-interfaces) if they don't suit your purpose. You can change most anything by writing your own HTML templates: a **custom BOX template** controls the layout of a box, while a **custom VIEW template** controls how a single atom is displayed. You drop the template file in your project's `templates/` folder and reference it from your script (`BOX<yourtemplate>` or a `HTML TEMPLATE` clause in a `VIEW`). See [Creating Custom BOX Templates](../../prototype/guides/creating-custom-box-templates) and [Creating Custom VIEW Templates](../../prototype/guides/creating-custom-view-templates).
+
+## Transactional interfaces {#transactional-interfaces}
+
+An interface may be declared **transactional** by writing the keyword `TRANSACTIONAL` in front of `INTERFACE` (or `API`):
+
+```
+TRANSACTIONAL INTERFACE EditBooking FOR Clerk : I[Booking]
+  [ "Guest"     : booking_guest    CRUd
+  , "Room"      : booking_room      CRUd
+  , "Check-in"  : booking_checkin   CRUd
+  , "Check-out" : booking_checkout  CRUd
+  ]
+```
+
+A transactional interface behaves as a single **optimistic transaction**:
+
+1. Entering the interface opens a transaction. Every field edit is **buffered**, not committed straight away.
+2. The transaction may be committed only when **all invariants hold**. Saving is blocked as long as any invariant rule is violated by the buffered state.
+3. **Save** commits the whole buffer **atomically**. After a successful commit the data is definitive, so ordinary `RULE`/`ENFORCE` maintenance applies to it as usual.
+4. **Cancel** discards the buffer (a rollback); navigating away without saving rolls back as well.
+5. Only invariants gate the commit. Process and signal rules behave as usual.
+
+Because the choice lives in the model, a transactional interface stays transactional wherever it is reused — including as a sub-interface via `LINKTO`:
+
+```
+INTERFACE Bookings FOR Clerk : I[SESSION]
+  [ "My bookings" : sessionBookings BOX<TABLE>
+      [ "When" : booking_period
+      , "Edit" : I[Booking] LINKTO INTERFACE EditBooking   -- opens transactionally
+      ]
+  ]
+```
+
+The compiler records the flag in the generated `interfaces.json` (as `isTransactional`), from which the prototype framework drives the transactional edit mode: a distinct accent border with an always-visible **Save** and **Cancel**. **Save** is disabled while any invariant is violated; hovering it then shows the concrete violation messages.
 
 ## CRUD {#CRUD}
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: ampersand
-version: 5.8.1
+version: 5.9.0
 author: Stef Joosten
 maintainer: stef.joosten@ou.nl
 synopsis: Toolsuite for automated design of enterprise information systems.

--- a/src/Ampersand/ADL1/P2A_Converters.hs
+++ b/src/Ampersand/ADL1/P2A_Converters.hs
@@ -984,6 +984,7 @@ pCtx2aCtx
             return
               Ifc
                 { ifcIsAPI = ifc_IsAPI pIfc,
+                  ifcIsTransactional = ifc_IsTransactional pIfc,
                   ifcname = name pIfc,
                   ifclbl = mLabel pIfc,
                   ifcRoles = ifc_Roles pIfc,

--- a/src/Ampersand/ADL1/PrettyPrinters.hs
+++ b/src/Ampersand/ADL1/PrettyPrinters.hs
@@ -290,8 +290,8 @@ instance Pretty P_Interface where
   pretty (P_Ifc isAPI isTransactional nm lbl roles obj _ _) =
     text (if isTransactional then "TRANSACTIONAL " else "")
       <> text (if isAPI then "API " else "INTERFACE ")
-      <~> nm
-      <~> lbl
+        <~> nm
+        <~> lbl
       <+> iroles
       <+> interfaceExpression
       <+> crud (obj_crud obj)

--- a/src/Ampersand/ADL1/PrettyPrinters.hs
+++ b/src/Ampersand/ADL1/PrettyPrinters.hs
@@ -287,8 +287,9 @@ instance Pretty TType where
   pretty = text . show
 
 instance Pretty P_Interface where
-  pretty (P_Ifc isAPI nm lbl roles obj _ _) =
-    text (if isAPI then "API " else "INTERFACE ")
+  pretty (P_Ifc isAPI isTransactional nm lbl roles obj _ _) =
+    text (if isTransactional then "TRANSACTIONAL " else "")
+      <> text (if isAPI then "API " else "INTERFACE ")
       <~> nm
       <~> lbl
       <+> iroles

--- a/src/Ampersand/Core/A2P_Converters.hs
+++ b/src/Ampersand/Core/A2P_Converters.hs
@@ -209,6 +209,7 @@ aInterface2pInterface :: Interface -> P_Interface
 aInterface2pInterface ifc =
   P_Ifc
     { ifc_IsAPI = ifcIsAPI ifc,
+      ifc_IsTransactional = ifcIsTransactional ifc,
       ifc_Name = name ifc,
       ifc_lbl = ifclbl ifc,
       ifc_Roles = ifcRoles ifc,

--- a/src/Ampersand/Core/AbstractSyntaxTree.hs
+++ b/src/Ampersand/Core/AbstractSyntaxTree.hs
@@ -821,6 +821,8 @@ instance Hashable AClassify where
 data Interface = Ifc
   { -- | is this interface of type API?
     ifcIsAPI :: !Bool,
+    -- | is this interface declared TRANSACTIONAL? (optimistic, invariant-guarded editing)
+    ifcIsTransactional :: !Bool,
     -- | The name of the interface
     ifcname :: !Name,
     ifclbl :: !(Maybe Label),

--- a/src/Ampersand/Core/ParseTree.hs
+++ b/src/Ampersand/Core/ParseTree.hs
@@ -979,6 +979,8 @@ instance Traced P_Population where
 data P_Interface = P_Ifc
   { -- | The interface is of type API
     ifc_IsAPI :: !Bool,
+    -- | The interface is declared TRANSACTIONAL (optimistic, invariant-guarded editing)
+    ifc_IsTransactional :: !Bool,
     -- | the name of the interface
     ifc_Name :: !Name,
     ifc_lbl :: !(Maybe Label),

--- a/src/Ampersand/FSpec/ToFSpec/ADL2FSpec.hs
+++ b/src/Ampersand/FSpec/ToFSpec/ADL2FSpec.hs
@@ -460,6 +460,7 @@ makeFSpec env context =
                       )
        in [ Ifc
               { ifcIsAPI = False,
+                ifcIsTransactional = False,
                 ifcname = name c,
                 ifclbl = Nothing,
                 ifcObj =
@@ -485,6 +486,7 @@ makeFSpec env context =
       =
       [ Ifc
           { ifcIsAPI = False,
+            ifcIsTransactional = False,
             ifcname = nm,
             ifclbl = Nothing,
             ifcObj =

--- a/src/Ampersand/Input/ADL1/Lexer.hs
+++ b/src/Ampersand/Input/ADL1/Lexer.hs
@@ -95,6 +95,7 @@ keywords =
     ++
     -- Keywords for interfaces
     [ "INTERFACE",
+      "TRANSACTIONAL",
       "FOR",
       "LINKTO",
       "API",

--- a/src/Ampersand/Input/ADL1/Parser.hs
+++ b/src/Ampersand/Input/ADL1/Parser.hs
@@ -989,6 +989,7 @@ pInterfaceIsAPI :: AmpParser Bool
 pInterfaceIsAPI = (toText1Unsafe "API" ==) <$> pInterfaceKey
 
 --- Transactional ::= 'TRANSACTIONAL'?
+
 -- | An interface may be prefixed with the keyword TRANSACTIONAL, opting it in
 --   to optimistic, invariant-guarded (buffered save/cancel) editing. See issue #1658.
 pTransactional :: AmpParser Bool

--- a/src/Ampersand/Input/ADL1/Parser.hs
+++ b/src/Ampersand/Input/ADL1/Parser.hs
@@ -802,11 +802,12 @@ pViewDefLegacy =
           pos = orig
         }
 
---- Interface ::= 'INTERFACE' ADLid Params? Roles? ':' Term (ADLid | Conid)? SubInterface?
+--- Interface ::= 'TRANSACTIONAL'? 'INTERFACE' ADLid Params? Roles? ':' Term (ADLid | Conid)? SubInterface?
 pInterface :: AmpParser P_Interface
 pInterface =
   build
     <$> currPos
+    <*> pTransactional
     <*> pInterfaceIsAPI
     <*> pNameWithOptionalLabel InterfaceName
     <*> pMaybe pRoles
@@ -818,6 +819,7 @@ pInterface =
     build ::
       Origin ->
       Bool ->
+      Bool ->
       (Name, Maybe Label) ->
       Maybe (NE.NonEmpty Role) ->
       Term TermPrim ->
@@ -825,9 +827,10 @@ pInterface =
       Maybe Name ->
       P_SubIfc TermPrim ->
       P_Interface
-    build p isAPI (nm, lbl) roles ctx mCrud mView sub =
+    build p isTransactional isAPI (nm, lbl) roles ctx mCrud mView sub =
       P_Ifc
         { ifc_IsAPI = isAPI,
+          ifc_IsTransactional = isTransactional,
           ifc_Name = nm,
           ifc_lbl = lbl,
           ifc_Roles = maybe [] NE.toList roles,
@@ -984,6 +987,12 @@ pInterfaceKey = pKey (toText1Unsafe "INTERFACE") <|> pKey (toText1Unsafe "API") 
 
 pInterfaceIsAPI :: AmpParser Bool
 pInterfaceIsAPI = (toText1Unsafe "API" ==) <$> pInterfaceKey
+
+--- Transactional ::= 'TRANSACTIONAL'?
+-- | An interface may be prefixed with the keyword TRANSACTIONAL, opting it in
+--   to optimistic, invariant-guarded (buffered save/cancel) editing. See issue #1658.
+pTransactional :: AmpParser Bool
+pTransactional = isJust <$> pMaybe (pKey (toText1Unsafe "TRANSACTIONAL"))
 
 --- Population ::= 'POPULATION' (NamedRel 'CONTAINS' Content | ConceptName 'CONTAINS' '[' ValueList ']')
 

--- a/src/Ampersand/Output/ToJSON/Interfaces.hs
+++ b/src/Ampersand/Output/ToJSON/Interfaces.hs
@@ -15,7 +15,8 @@ data JSONInterface = JSONInterface
   { ifcJSONname :: Text,
     ifcJSONlabel :: Text,
     ifcJSONifcObject :: JSONObjectDef,
-    ifcJSONisAPI :: Bool
+    ifcJSONisAPI :: Bool,
+    ifcJSONisTransactional :: Bool
   }
   deriving (Generic, Show)
 
@@ -138,7 +139,8 @@ instance JSON Interface JSONInterface where
       { ifcJSONname = fullName interface,
         ifcJSONlabel = label interface,
         ifcJSONifcObject = fromAmpersand env fSpec (BxExpr $ ifcObj interface),
-        ifcJSONisAPI = ifcIsAPI interface
+        ifcJSONisAPI = ifcIsAPI interface,
+        ifcJSONisTransactional = ifcIsTransactional interface
       }
 
 instance JSON Cruds JSONCruds where

--- a/src/Ampersand/Test/Parser/ArbitraryTree.hs
+++ b/src/Ampersand/Test/Parser/ArbitraryTree.hs
@@ -474,6 +474,7 @@ instance Arbitrary P_Interface where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
       <*> makeObj InterfaceKind
       <*> arbitrary
       <*> safeText


### PR DESCRIPTION
Closes #1658 (compiler side).

## What

Adds a model-level opt-in for optimistic, invariant-guarded editing. A modeller writes `TRANSACTIONAL` in front of `INTERFACE` (or `API`):

```
TRANSACTIONAL INTERFACE EditBooking FOR Clerk : I[Booking]
BOX[ "Guest"     : bookingGuest    CRUd
   , "Room"      : bookingRoom      CRUd
   , "Check-in"  : bookingCheckin   CRUd
   , "Check-out" : bookingCheckout  CRUd
   ]
```

The compiler records the flag as `isTransactional` in `generics/interfaces.json`, from which the prototype framework drives its already-existing buffered save/cancel edit mode.

## Changes (compiler)

- **Lexer** — reserve keyword `TRANSACTIONAL`.
- **Parser** — `pInterface` parses an optional leading `TRANSACTIONAL` into a `Bool`.
- **AST** — `ifc_IsTransactional` on `P_Interface`, `ifcIsTransactional` on `Interface`; threaded through the P2A/A2P converters and the default-theme generated interfaces in `ADL2FSpec` (both `False`).
- **JSON** — emit `isTransactional` per interface in `interfaces.json`.
- **Pretty-printer + Arbitrary** — updated so the parser roundtrip QuickCheck holds.
- **Docs** — `docs/reference-material/interfaces.md` gains a *Transactional interfaces* section with the booking example.

Because the flag lives in the model, a transactional interface stays transactional wherever it is reused, including as a `LINKTO` sub-interface.

## Acceptance criteria (this repo)

- [x] Compiler parses `TRANSACTIONAL INTERFACE` and records the flag in `interfaces.json` (`isTransactional`).
- [x] Documented in the reference material with the booking example.

The remaining criteria (accent border, always-visible in-border Save/Cancel, hover-to-see-violations) live in the **PrototypeFramework** repo and are out of scope here.

## Verification

- Clean `stack build`.
- `ampersand check` on a `TRANSACTIONAL` sample passes.
- Generated `interfaces.json` carries `"isTransactional": true` for the declared interface and `false` for normal / auto-generated ones.
- `ampersand test` — the **Prettyprint/Parser roundtrip** QuickCheck passes. The 166 regression failures on my machine are all `ExitFailure 60` (no local MariaDB/PHP), pre-existing and unrelated.

## Note

`TRANSACTIONAL` is now a reserved word; any existing model using it as an identifier must rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)