### PR TITLE
feat(PrototypeContext): show role-less interfaces in the nav menu ("Any" wildcard)

### DIFF
--- a/AmpersandData/PrototypeContext/Navbar.ifc
+++ b/AmpersandData/PrototypeContext/Navbar.ifc
@@ -21,7 +21,13 @@ CONTEXT PrototypeContext IN ENGLISH
         ]
 
     --[SYSTEM INTERFACES to query menu items]------------------------------------------------------
-    API PrototypeContext.MenuItems LABEL "Menu items" FOR SYSTEM: PrototypeContext.sessionActiveRoles[SESSION*PrototypeContext.Role];PrototypeContext.navItemRoles~;PrototypeContext.isVisible BOX
+    -- A menu item is shown when one of the session's active roles is coupled to it (via navItemRoles).
+    -- A role-less interface is coupled to the wildcard role "Any"; it must show for any AUTHENTICATED
+    -- session (mirroring the access-control rule), but not for the Anonymous (no-user) session. So the
+    -- session's effective roles are its active roles PLUS "Any" whenever it has a non-Anonymous active
+    -- role. `(sessionActiveRoles - sessionActiveRoles;"Anonymous")` keeps the non-Anonymous active roles;
+    -- crossing (#) their sessions with "Any" grants those sessions the wildcard role for menu filtering.
+    API PrototypeContext.MenuItems LABEL "Menu items" FOR SYSTEM: ( PrototypeContext.sessionActiveRoles[SESSION*PrototypeContext.Role] \/ ( ( PrototypeContext.sessionActiveRoles[SESSION*PrototypeContext.Role] - PrototypeContext.sessionActiveRoles[SESSION*PrototypeContext.Role];"Anonymous" ) # "Any" ) );PrototypeContext.navItemRoles~;PrototypeContext.isVisible BOX
         [ "id"              : I
         , "label"           : PrototypeContext.label[PrototypeContext.NavMenuItem*PrototypeContext.Label]
         , "seqNr"           : PrototypeContext.seqNr


### PR DESCRIPTION
## Problem

Under the any-role model, an interface without a `FOR`-clause is coupled to the wildcard role `"Any"`. The framework already treats `"Any"` as a wildcard for **access** (an authenticated role reaches such an interface). But the **nav menu** did not: the `MenuItems` query filtered items by `sessionActiveRoles;navItemRoles~`, matching only concrete active roles. A role-less item has `navItemRoles = {"Any"}`, so it never appeared in the menu — reachable by URL, but invisible in the navigation.

Concretely, the `transactional-demo` "Bookings" interface (no `FOR`-clause) was accessible but absent from the left menu.

## Fix

Add `"Any"` to the session's *effective* roles for menu filtering whenever the session has a **non-Anonymous** active role (mirroring the access rule — `"Any"` is satisfied by any authenticated role, never by Anonymous):

```
( sessionActiveRoles
  \/ (sessionActiveRoles - sessionActiveRoles;"Anonymous") # "Any"
) ; navItemRoles~ ; isVisible
```

`(sessionActiveRoles - sessionActiveRoles;"Anonymous")` keeps the non-Anonymous active roles; crossing (`#`) their sessions with `"Any"` grants those sessions the wildcard role, so role-less items show for authenticated sessions only.

## Verification

Deployed `transactional-demo` on the PrototypeFramework:
- active **SYSTEM** / **Administrator** → "Bookings" appears in the menu (and is 200); menu is not over-broadened
- active **Anonymous** → "Bookings" absent from the menu (and 403)

Independent of #1661 (verified on a branch off `v5.9.1` without the `isTotSur` fix): the cross product `#` does not go through the `V;singleton` normalisation, so this stands alone. The two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)